### PR TITLE
Automatically tag bug report issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,7 +2,7 @@
 name: Bug report
 about: Create a report to help us improve
 title: ''
-labels: ''
+labels: 'bug'
 assignees: ''
 
 ---


### PR DESCRIPTION
A small change to tag new bug reports, could be useful for sorting through issues as this repo grows.

It would be good to add additional issue templates for things like feature requests or queries.

You could also make use of `config.yml` (<https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository>) to make a more guided issue flow, perhaps adding a link to the Nvidia forums if appropriate.