### PR TITLE
Enforce C standard compliance and fix ACPI null pointer dereference

### DIFF
--- a/kernel-open/nvidia-drm/nvidia-drm-crtc.c
+++ b/kernel-open/nvidia-drm/nvidia-drm-crtc.c
@@ -1141,11 +1141,13 @@ void nv_drm_enumerate_crtcs_and_planes(
         }
 
         for (layer = 0; layer < pResInfo->numLayers[i]; layer++) {
+            struct drm_plane *overlay_plane;
+
             if (layer == NVKMS_KAPI_LAYER_PRIMARY_IDX) {
                 continue;
             }
 
-            struct drm_plane *overlay_plane =
+            overlay_plane =
                 nv_drm_plane_create(nv_dev->dev,
                                     DRM_PLANE_TYPE_OVERLAY,
                                     layer,

--- a/kernel-open/nvidia/nv-acpi.c
+++ b/kernel-open/nvidia/nv-acpi.c
@@ -737,6 +737,9 @@ void NV_API_CALL nv_acpi_methods_uninit(void)
 #if defined(NV_ACPI_BUS_GET_DEVICE_PRESENT)
     acpi_bus_get_device(nvif_parent_gpu_handle, &device);
 
+    if (device == NULL)
+        return;
+        
     nv_uninstall_notifier(device->driver_data, nv_acpi_event);
 #endif
 


### PR DESCRIPTION
Simple fix for a minor compiler warning to dip my toes into this codebase.