### PR TITLE
Use STATE_MASK instead of MAP_MASK

### DIFF
--- a/src/nvidia/src/kernel/gpu/mem_mgr/phys_mem_allocator/addrtree.c
+++ b/src/nvidia/src/kernel/gpu/mem_mgr/phys_mem_allocator/addrtree.c
@@ -1497,9 +1497,7 @@ _addrtreeNodeIndexHasSeeChildSet
     NvU32 newIndex = 0;
     *pState = STATE_FREE;
 
-    // TODO: try this for only STATE_MASK, because stats will only
-    // get corrupted if the STATE_MASK values differ.
-    PMA_PAGESTATUS stateMask = MAP_MASK; // check all states TODO
+    PMA_PAGESTATUS stateMask = STATE_MASK; // check all states TODO
 
     while(n->level != pNode->level)
     {


### PR DESCRIPTION
This commit fixes a TODO entry in addrtree.c to use STATE_MASK when referring to stateMask in _addrtreeNodeIndexHasSeeChildSet; only the state mask should matter in this case.