### PR TITLE
Improve `conftest.sh` Script

### DIFF
--- a/kernel-open/conftest.sh
+++ b/kernel-open/conftest.sh
@@ -628,10 +628,10 @@ compile_test() {
         set_pages_array_uc)
             #
             # Determine if the set_pages_array_uc() function is present.
-            # It does not exist on all architectures. 
-            # 
-            # set_pages_array_uc() was added by commit 
-            # 0f3507555f6fa4acbc85a646d6e8766230db38fc ("x86, CPA: Add 
+            # It does not exist on all architectures.
+            #
+            # set_pages_array_uc() was added by commit
+            # 0f3507555f6fa4acbc85a646d6e8766230db38fc ("x86, CPA: Add
             # set_pages_arrayuc and set_pages_array_wb") in v2.6.30-rc1 (Thu Mar
             # 19 14:51:15 2009)
             #
@@ -1040,7 +1040,7 @@ compile_test() {
             #
             # Determine if mdev_get_type_group_id() function is present or not
             #
-            # Added by commit 15fcc44be0c7a ("vfio/mdev: Add 
+            # Added by commit 15fcc44be0c7a ("vfio/mdev: Add
             # mdev/mtype_get_type_group_id()") in v5.13
             #
             CODE="
@@ -1250,7 +1250,7 @@ compile_test() {
             #
             # The commit c28198889c15 removed the function
             # 'PDE_DATA()', and replaced it with 'pde_data()'
-            # ("proc: remove PDE_DATA() completely") in v5.17-rc1. 
+            # ("proc: remove PDE_DATA() completely") in v5.17-rc1.
             #
             CODE="
             #include <linux/proc_fs.h>
@@ -3965,7 +3965,7 @@ compile_test() {
             #
             # Determine if the 'struct proc_ops' type is present.
             #
-            # Added by commit d56c0d45f0e2 ("proc: decouple proc from VFS with 
+            # Added by commit d56c0d45f0e2 ("proc: decouple proc from VFS with
             # "struct proc_ops"") in 5.6-rc1
             #
             CODE="
@@ -4691,7 +4691,7 @@ compile_test() {
             #
             # Note: KERNELRELEASE and ARCH are defined by Kbuild and automatically
             # passed down to conftest.sh as env vars.
-            
+
             MLNX_OFED_KERNEL_DIR=/usr/src/ofa_kernel
             VAR_DKMS_SOURCES_DIR=$(test -d /var/lib/dkms/mlnx-ofed-kernel &&
                                    ls -d /var/lib/dkms/mlnx-ofed-kernel/*/build 2>/dev/null)
@@ -5378,7 +5378,7 @@ case "$5" in
         #  version gcc 3.2.3
         #
         #  As of this writing, GCC uses a version number as x.y.z and below
-        #  are the typical version strings seen with various distributions. 
+        #  are the typical version strings seen with various distributions.
         #  gcc (GCC) 4.4.7 20120313 (Red Hat 4.4.7-23)
         #  gcc version 4.8.5 20150623 (Red Hat 4.8.5-39) (GCC)
         #  gcc (GCC) 8.3.1 20190507 (Red Hat 8.3.1-4)
@@ -5390,7 +5390,7 @@ case "$5" in
         #
         #  In order to extract GCC version correctly for version strings
         #  like the last one above, we first check for x.y.z and if that
-        #  fails, we fallback to x.y format. 
+        #  fails, we fallback to x.y format.
         VERBOSE=$6
 
         kernel_compile_h=$OUTPUT/include/generated/compile.h

--- a/kernel-open/conftest.sh
+++ b/kernel-open/conftest.sh
@@ -500,12 +500,12 @@ get_configuration_option() {
 }
 
 check_for_ib_peer_memory_symbols() {
-    local kernel_dir="$1"
-    local module_symvers="${kernel_dir}/Module.symvers"
+    kernel_dir="$1"
+    module_symvers="${kernel_dir}/Module.symvers"
 
-    local sym_ib_register="ib_register_peer_memory_client"
-    local sym_ib_unregister="ib_unregister_peer_memory_client"
-    local tab='	'
+    sym_ib_register="ib_register_peer_memory_client"
+    sym_ib_unregister="ib_unregister_peer_memory_client"
+    tab='	'
 
     # Return 0 for true(no errors), 1 for false
     if [ ! -f "${module_symvers}" ]; then

--- a/kernel-open/conftest.sh
+++ b/kernel-open/conftest.sh
@@ -73,8 +73,8 @@ translate_and_preprocess_header_files() {
     # strings, without special handling of the beginning or the end of the line.
     TEST_CFLAGS=`echo "-E -M $CFLAGS " | sed -e 's/\( -M[DG]\)* / /g'`
 
-    for file in $@; do
-        local file_define=NV_`echo $file | tr '/.' '_' | tr '-' '_' | tr 'a-z' 'A-Z'`_PRESENT
+    for file in "$@"; do
+        file_define=NV_`echo $file | tr '/.' '_' | tr '-' '_' | tr 'a-z' 'A-Z'`_PRESENT
 
         CODE="#include <$file>"
 
@@ -5687,7 +5687,7 @@ case "$5" in
 
         HASH=$(get_configuration_option CONFIG_MODULE_SIG_HASH)
 
-        if [ $? -eq 0 ] && [ -n $HASH ]; then
+        if [ $? -eq 0 ] && [ -n "$HASH" ]; then
             echo $HASH
             exit 0
         else


### PR DESCRIPTION
- Remove non-posix local usage
- Remove trailing whitespace
- Fix broken test caused by missing quotes