### PR TITLE
Match objectName declaration in inforom_nvswitch.h

### DIFF
--- a/src/common/nvswitch/kernel/inc/inforom/inforom_nvswitch.h
+++ b/src/common/nvswitch/kernel/inc/inforom/inforom_nvswitch.h
@@ -90,23 +90,23 @@ struct inforom
 // Generic InfoROM APIs
 NvlStatus nvswitch_initialize_inforom(nvswitch_device *device);
 NvlStatus nvswitch_inforom_read_object(nvswitch_device* device,
-                const char *objectName, const char *pObjectFormat,
+                const char objectName[3], const char *pObjectFormat,
                 NvU8 *pPackedObject, void *pObject);
 NvlStatus nvswitch_inforom_write_object(nvswitch_device* device,
-                const char *objectName, const char *pObjectFormat,
+                const char objectName[3], const char *pObjectFormat,
                 void *pObject, NvU8 *pOldPackedObject);
 void nvswitch_destroy_inforom(nvswitch_device *device);
 NvlStatus nvswitch_inforom_add_object(struct inforom *pInforom,
                                     INFOROM_OBJECT_HEADER_V1_00 *pHeader);
 NvlStatus nvswitch_inforom_get_object_version_info(nvswitch_device *device,
-                const char *objectName, NvU8 *pVersion, NvU8 *pSubVersion);
+                const char objectName[3], NvU8 *pVersion, NvU8 *pSubVersion);
 void *nvswitch_add_halinfo_node(NVListPtr head, int type, int size);
 void *nvswitch_get_halinfo_node(NVListPtr head, int type);
 void nvswitch_inforom_post_init(nvswitch_device *device);
 NvlStatus nvswitch_initialize_inforom_objects(nvswitch_device *device);
 void nvswitch_destroy_inforom_objects(nvswitch_device *device);
 NvlStatus nvswitch_inforom_load_object(nvswitch_device* device,
-                struct inforom *pInforom, const char *objectName,
+                struct inforom *pInforom, const char objectName[3],
                 const char *pObjectFormat, NvU8 *pPackedObject, void *pObject);
 void nvswitch_inforom_read_static_data(nvswitch_device *device,
                 struct inforom  *pInforom, RM_SOE_SMBPBI_INFOROM_DATA *pData);


### PR DESCRIPTION
Match usage in the .c file and silence some compiler warnings.