### PR TITLE
common/nvswitch: [fru_nvswitch] do not increment index before performing loop operation

### DIFF
--- a/src/common/nvswitch/kernel/ipmi/fru_nvswitch.c
+++ b/src/common/nvswitch/kernel/ipmi/fru_nvswitch.c
@@ -37,7 +37,7 @@ _nvswitch_calculate_checksum
     NvU32 i;
     NvU8 checksum = 0;
 
-    for (i = 0; i < size; ++i)
+    for (i = 0; i < size; i++)
     {
         checksum += data[i];
     }


### PR DESCRIPTION
This should:
- Take account the first byte of the data array into the checksum
- Prevent read overflows caused by the last iteration of the loop operation

P.S.: This commit is being made under the naive assumption of the data structure for `NvU8 *data`, and is done so because I have not found a use of this function inside the source archive. Kindly just reject this PR if it's actually intentional.