### PR TITLE
Efficiently adds the latest tag release on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 # NVIDIA Linux Open GPU Kernel Module Source
 
-![latest open-gpu-kernel-modules tag](https://img.shields.io/github/v/tag/NVIDIA/open-gpu-kernel-modules?include_prereleases)
-![latest open-gpu-kernel-modules release](https://img.shields.io/github/v/release/NVIDIA/open-gpu-kernel-modules?include_prereleases&style=flat-square)
+[![latest open-gpu-kernel-modules tag][latest-tag]][latest-driver-link]
+
+[latest-tag]: https://img.shields.io/github/v/tag/NVIDIA/open-gpu-kernel-modules?include_prereleases
+[latest-driver-link]: https://www.nvidia.com/download/driverResults.aspx/187834/en
 
 This is the source release of the NVIDIA Linux open GPU kernel modules.
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 # NVIDIA Linux Open GPU Kernel Module Source
 
-This is the source release of the NVIDIA Linux open GPU kernel modules,
-version 515.43.04.
+![latest open-gpu-kernel-modules tag](https://img.shields.io/github/v/tag/NVIDIA/open-gpu-kernel-modules?include_prereleases)
+![latest open-gpu-kernel-modules release](https://img.shields.io/github/v/release/NVIDIA/open-gpu-kernel-modules?include_prereleases&style=flat-square)
+
+This is the source release of the NVIDIA Linux open GPU kernel modules.
 
 
 ## How to Build
@@ -17,7 +19,7 @@ as root:
 
 Note that the kernel modules built here must be used with gsp.bin
 firmware and user-space NVIDIA GPU driver components from a corresponding
-515.43.04 driver release.  This can be achieved by installing
+latest driver release.  This can be achieved by installing
 the NVIDIA GPU driver from the .run file using the `--no-kernel-modules`
 option.  E.g.,
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ as root:
 
 Note that the kernel modules built here must be used with gsp.bin
 firmware and user-space NVIDIA GPU driver components from a corresponding
-latest driver release.  This can be achieved by installing
+[latest driver release][latest-driver-link].  This can be achieved by installing
 the NVIDIA GPU driver from the .run file using the `--no-kernel-modules`
 option.  E.g.,
 


### PR DESCRIPTION
This change avoids rewriting the documentation every time there is a change to the latest version.

- Use shields.io to provide the latest tag/release label.
- Rewrite how to build section to point latest driver release.

Note that this PR requires https://github.com/login/oauth/authorize?client_id=cceb16b11fcb57269101&redirect_uri=https%3A%2F%2Fimg.shields.io%2Fgithub-auth%2Fdone to avoids GitHub badge errors, it might be because you hit GitHub's rate limits.