### PR TITLE
Update HTTP link to HTTPS

### DIFF
--- a/src/nvidia-modeset/src/nvkms-framelock.c
+++ b/src/nvidia-modeset/src/nvkms-framelock.c
@@ -459,7 +459,7 @@ static NVFrameLockEvoPtr AllocFrameLockEvo(NVDevEvoPtr pDevEvo,
         nvEvoLogDev(pDevEvo, EVO_LOG_ERROR, "The firmware on this Quadro Sync "
                     "card is not compatible with the GPUs connected to it."
                     "  Please visit "
-                    "<http://www.nvidia.com/object/quadro-sync.html> "
+                    "<https://www.nvidia.com/object/quadro-sync.html> "
                     "for instructions on installing the correct firmware.");
         goto fail;
     }


### PR DESCRIPTION
`http://www.nvidia.com` redirects to `https://www.nvidia.com`, so linking to http is reduntant.
More importantly, it could be considered a security issue, do to the nature of plain http. An attacker could perform a MITM attack and redirect the HTTP request to a malicious website.
```
> GET / HTTP/1.1
> Host: www.nvidia.com

Response:
< HTTP/1.1 307 Temporary Redirect
< Location: https://www.nvidia.com/
```