### PR TITLE
Enable Multi-Arch Builds and Verification via CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ commands:
     parameters:
       build-args:
         type: string
-        default: "-j`nproc`"
+        default: "-j$(nproc)"
       NV_VERBOSE:
         type: string
         default: "0"
@@ -33,7 +33,7 @@ commands:
     parameters:
       install-args:
         type: string
-        default: "-j`nproc`"
+        default: "-j$(nproc)"
     steps:
       - checkout
       - attach_workspace:
@@ -67,7 +67,7 @@ jobs:
     executor: << parameters.architecture >>
     steps:
       - build-kernel-module:
-          build-args: "-j`nproc`"
+          build-args: "-j$(nproc)"
 
   install:
     parameters:
@@ -76,7 +76,7 @@ jobs:
     executor: << parameters.architecture >>
     steps:
       - install-kernel-module:
-          install-args: "-j`nproc`"
+          install-args: "-j$(nproc)"
 
 workflows:
   multi-arch-build:


### PR DESCRIPTION
Added CircleCI to handle CI/CD needs. 

Currently the workflow builds the kernel modules on both `arm64` and `amd64`. After building the kernel modules, it installs the newly made kernel modules on both architectures as well. I think this is a better approach than #31 and #108 as we have access to both architectures to verify if there are compilation errors/runtime errors. 

CircleCI also offers GPU instances in which we could do testing on the newly build kernel modules. @aritger If you are interested in using CircleCI for this project let me know. I am happy to see if we can enable GPU instances on our OSS tier. More information on the CircleCI's OSS tier [here](https://circleci.com/open-source/).

With CircleCI, we also can publishes releases instead of just using tags for new releases of the driver. I think that would look a little cleaner for the community. 

This is the [link](https://app.circleci.com/pipelines/github/james-crowley/open-gpu-kernel-modules/7/workflows/14613590-26b5-4e28-b582-3de309cef378) to the current build.

Fixes #31 
Fixes #108 

