### PR TITLE
Avoid potential compilation error with old gcc

### DIFF
--- a/src/nvidia/inc/libraries/nvoc/prelude.h
+++ b/src/nvidia/inc/libraries/nvoc/prelude.h
@@ -243,7 +243,7 @@ typedef struct NVOC_CLASS_INFO
 #pragma warning(error: 1786) // treat deprecated as error (globally affected)
 #define NVOC_PRIVATE_FIELD(x)       __attribute__((deprecated(#x " is a private field"))) x
 #define NVOC_PRIVATE_FUNCTION(x)    __attribute__((deprecated(#x " is a private function"))) x
-#elif defined(__GNUC__) || defined(__GNUG__) // gcc
+#elif __GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 5) // gcc
 #pragma GCC diagnostic error "-Wdeprecated-declarations" // treat deprecated as error (globally affected)
 #define NVOC_PRIVATE_FIELD(x)       __attribute__((deprecated(#x " is a private field"))) x
 #define NVOC_PRIVATE_FUNCTION(x)    __attribute__((error(#x " is a private function"))) x


### PR DESCRIPTION
Though it seems that NVOC private feature is not used now, I think
it is still not bad to fix this now in case of any future errors.

The optional message for deprecated attribute is introduced in
gcc 4.5[1]. To avoid potential compilation error, we should check
gcc version before using it.

Also, \_\_GNUG\_\_ is for testing GNU C++ compiler, so we should
remove it as we are targeting C here.

[1] https://gcc.gnu.org/bugzilla/show_bug.cgi?id=43666