### PR TITLE
[~] Remove deprecated WIN32 defines

### DIFF
--- a/src/common/sdk/nvidia/inc/nvos.h
+++ b/src/common/sdk/nvidia/inc/nvos.h
@@ -355,11 +355,8 @@ typedef struct
 } NVOS05_PARAMETERS;
 
 /* Valid values for hClass in Nv01AllocEvent */
-/* Note that NV01_EVENT_OS_EVENT is same as NV01_EVENT_WIN32_EVENT */
-/* TODO: delete the WIN32 name */
 #define  NV01_EVENT_KERNEL_CALLBACK                                (0x00000078)
 #define  NV01_EVENT_OS_EVENT                                       (0x00000079)
-#define  NV01_EVENT_WIN32_EVENT                             NV01_EVENT_OS_EVENT
 #define  NV01_EVENT_KERNEL_CALLBACK_EX                             (0x0000007E)
 
 /* NOTE: NV01_EVENT_KERNEL_CALLBACK is deprecated. Please use NV01_EVENT_KERNEL_CALLBACK_EX. */

--- a/src/nvidia/arch/nvalloc/unix/src/os.c
+++ b/src/nvidia/arch/nvalloc/unix/src/os.c
@@ -1323,7 +1323,7 @@ NV_STATUS osEventNotificationWithInfo
         switch (pNotifyEvent->NotifyType)
         {
             case NV_EVENT_BUFFER_BIND:
-            case NV01_EVENT_WIN32_EVENT:
+            case NV01_EVENT_OS_EVENT:
             {
                 nv_event_t *event = NvP64_VALUE(pNotifyEvent->Data);
                 postEvent(event,

--- a/src/nvidia/generated/g_allclasses.h
+++ b/src/nvidia/generated/g_allclasses.h
@@ -313,12 +313,6 @@
 #ifndef NV1_EVENT_OS_EVENT
 #define NV1_EVENT_OS_EVENT                       (0x00000079) // alias
 #endif
-#ifndef NV01_EVENT_WIN32_EVENT
-#define NV01_EVENT_WIN32_EVENT                   (0x00000079) // alias
-#endif
-#ifndef NV1_EVENT_WIN32_EVENT
-#define NV1_EVENT_WIN32_EVENT                    (0x00000079) // alias
-#endif
 
 #ifndef NV01_EVENT_KERNEL_CALLBACK_EX
 #define NV01_EVENT_KERNEL_CALLBACK_EX            (0x0000007e)

--- a/src/nvidia/src/kernel/gpu/nvdec/kernel_nvdec_engdesc.c
+++ b/src/nvidia/src/kernel/gpu/nvdec/kernel_nvdec_engdesc.c
@@ -40,7 +40,7 @@
  * This function returns an engine descriptor corresponding to the class
  * and engine instance passed in.
  *
- * @params[in] externalClassId  Id of classs being allocated
+ * @params[in] externalClassId  Id of class being allocated
  * @params[in] pAllocParams     void pointer containing creation parameters.
  *
  * @returns
@@ -56,15 +56,15 @@ nvdecGetEngineDescFromAllocParams
 {
     CALL_CONTEXT *pCallContext = resservGetTlsCallContext();
     NvU32                        engineInstance    = 0;
-    NV_BSP_ALLOCATION_PARAMETERS *pNvdecAllocParms = pAllocParams;
+    NV_BSP_ALLOCATION_PARAMETERS *pNvdecAllocParams = pAllocParams;
 
-    NV_ASSERT_OR_RETURN((pNvdecAllocParms != NULL), ENG_INVALID);
+    NV_ASSERT_OR_RETURN((pNvdecAllocParams != NULL), ENG_INVALID);
 
-    if (pNvdecAllocParms->size != sizeof(NV_BSP_ALLOCATION_PARAMETERS))
+    if (pNvdecAllocParams->size != sizeof(NV_BSP_ALLOCATION_PARAMETERS))
     {
         NV_PRINTF(LEVEL_ERROR, "createParams size mismatch (rm = 0x%x / client = 0x%x)\n",
                   (NvU32) sizeof(NV_BSP_ALLOCATION_PARAMETERS),
-                  pNvdecAllocParms->size);
+                  pNvdecAllocParams->size);
         DBG_BREAKPOINT();
         return ENG_INVALID;
     }
@@ -82,7 +82,7 @@ nvdecGetEngineDescFromAllocParams
         case NVC4B0_VIDEO_DECODER:
         case NVC6B0_VIDEO_DECODER:
         case NVC7B0_VIDEO_DECODER:
-            engineInstance = pNvdecAllocParms->engineInstance;
+            engineInstance = pNvdecAllocParams->engineInstance;
             break;
         default:
             return ENG_INVALID;


### PR DESCRIPTION
It's time to remove WIN32 specific names completely.

Also there are generated files 
by **rmconfig** [rmconfig.h] 
and **chip-config** [g_allclasses.h]) that shouldn't be modified manually. 

Unluckily, these generation tools are not available in repo.