### PR TITLE
Make `nvLogBase2` more efficient

### DIFF
--- a/src/nvidia/src/lib/base_utils.c
+++ b/src/nvidia/src/lib/base_utils.c
@@ -35,19 +35,16 @@
 //
 NvU32 nvLogBase2(NvU64 val)
 {
-    NvU32 i;
+    NvU32 i = 0;
 
-    NV_ASSERT(((val)&(val-1)) == 0);
+    // Use two NV_ASSERTs for better error identification
+    NV_ASSERT(val != 0);
+    NV_ASSERT(((val) & (val - 1)) == 0);
 
-    for (i = 0; i < 64; i++)
+    while ((val >>= 1))
     {
-       if ((1ull << i) == val)
-       {
-           break;
-       }
+        i++;
     }
-
-    NV_ASSERT(i < 64);
 
     return i;
 }
@@ -355,4 +352,3 @@ NvU32 nvStringLen(const char * str)
         ;
     return i - 1;
 }
-


### PR DESCRIPTION
The loop is more simple and easy to understand. Naive testing shows an improvement of 2x in speed.

In every single test, the new loop seems to perform better (tested using 100000000 random integers each). The median time of execution for the old loop on my machine is approximately 5.25 seconds, whereas the median time of execution for the new loop is 2.6 seconds.