### PR TITLE
change _flcnQueueCmdWait_IMPL storage-class specifier to static

### DIFF
--- a/src/common/nvswitch/kernel/flcn/flcnqueue_nvswitch.c
+++ b/src/common/nvswitch/kernel/flcn/flcnqueue_nvswitch.c
@@ -1578,7 +1578,7 @@ _flcnQueueCmdValidate
  * @return  NV_ERR_TIMEOUT
  *      A timeout occurred before the command completed.
  */
-NV_STATUS
+static NV_STATUS
 _flcnQueueCmdWait_IMPL
 (
     nvswitch_device *device,


### PR DESCRIPTION
sparse reports this building issue on RHEL
../common/nvswitch/kernel/flcn/flcnqueue_nvswitch.c:1582:1:
  warning: symbol '_flcnQueueCmdWait_IMPL' was not declared. Should it be static?

The function _flcnQueueCmdWait_IMPL is only used in its defining file
flcnqueue_nvswitch.c, so it should be a static function as the
other *IMPL() functions are.

Signed-off-by: Tom Rix <trix@redhat.com>