### PR TITLE
silence double free warning

### DIFF
--- a/kernel-open/nvidia/nv.c
+++ b/kernel-open/nvidia/nv.c
@@ -1385,7 +1385,7 @@ failed:
         if(nvl->irq_count)
             NV_KFREE(nvl->irq_count, nvl->num_intr * sizeof(nv_irq_count_info_t));
     }
-    if (nv->flags & NV_FLAG_USES_MSIX)
+    else if (nv->flags & NV_FLAG_USES_MSIX)
     {
         nv->flags &= ~NV_FLAG_USES_MSIX;
         pci_disable_msix(nvl->pci_dev);


### PR DESCRIPTION
clang static analysis reports this issue on RHEL
open-gpu-kernel-modules/kernel-open/nvidia/nv.c:1392:9: warning: Attempt to free released memory [unix.Malloc]
        NV_KFREE(nvl->irq_count, nvl->num_intr*sizeof(nv_irq_count_info_t));
        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

This is a false positive, NV_FLAG_USES_MSIX and NV_FLAG_USES_MSI
are mutually exclusive.  Convert the NV_FLAG_USE_MSIX 'if' to an
'if else'

Signed-off-by: Tom Rix <trix@redhat.com>