### PR TITLE
Add NULL check for pNumaMemAddr

### DIFF
--- a/src/nvidia/arch/nvalloc/unix/src/osapi.c
+++ b/src/nvidia/arch/nvalloc/unix/src/osapi.c
@@ -4586,7 +4586,7 @@ NV_STATUS NV_API_CALL rm_get_gpu_numa_info(
     void               *fp;
     NV_STATUS           status = NV_OK;
 
-    if ((pNid == NULL) || (pNumaMemAddr == NULL) || (pNumaMemAddr == NULL))
+    if ((pNid == NULL) || (pNumaMemAddr == NULL) || (pNumaMemSize == NULL))
     {
         return NV_ERR_INVALID_ARGUMENT;
     }


### PR DESCRIPTION
pNumaMemSize is not NULL checked (instead, pNumaMemAddr is checked twice) 
Fixes: #55