### PR TITLE
Remove outdated macros

### DIFF
--- a/kernel-open/nvidia-modeset/nv-kthread-q.c
+++ b/kernel-open/nvidia-modeset/nv-kthread-q.c
@@ -48,17 +48,6 @@
 // into the queue, and those functions will be run in the context of the
 // queue's kthread.
 
-#ifndef WARN
-    // Only *really* old kernels (2.6.9) end up here. Just use a simple printk
-    // to implement this, because such kernels won't be supported much longer.
-    #define WARN(condition, format...) ({                    \
-        int __ret_warn_on = !!(condition);                   \
-        if (unlikely(__ret_warn_on))                         \
-            printk(KERN_ERR format);                         \
-        unlikely(__ret_warn_on);                             \
-    })
-#endif
-
 #define NVQ_WARN(fmt, ...)                                   \
     do {                                                     \
         if (in_interrupt()) {                                \

--- a/kernel-open/nvidia-uvm/nv-kthread-q.c
+++ b/kernel-open/nvidia-uvm/nv-kthread-q.c
@@ -48,17 +48,6 @@
 // into the queue, and those functions will be run in the context of the
 // queue's kthread.
 
-#ifndef WARN
-    // Only *really* old kernels (2.6.9) end up here. Just use a simple printk
-    // to implement this, because such kernels won't be supported much longer.
-    #define WARN(condition, format...) ({                    \
-        int __ret_warn_on = !!(condition);                   \
-        if (unlikely(__ret_warn_on))                         \
-            printk(KERN_ERR format);                         \
-        unlikely(__ret_warn_on);                             \
-    })
-#endif
-
 #define NVQ_WARN(fmt, ...)                                   \
     do {                                                     \
         if (in_interrupt()) {                                \

--- a/kernel-open/nvidia/nv-kthread-q.c
+++ b/kernel-open/nvidia/nv-kthread-q.c
@@ -48,17 +48,6 @@
 // into the queue, and those functions will be run in the context of the
 // queue's kthread.
 
-#ifndef WARN
-    // Only *really* old kernels (2.6.9) end up here. Just use a simple printk
-    // to implement this, because such kernels won't be supported much longer.
-    #define WARN(condition, format...) ({                    \
-        int __ret_warn_on = !!(condition);                   \
-        if (unlikely(__ret_warn_on))                         \
-            printk(KERN_ERR format);                         \
-        unlikely(__ret_warn_on);                             \
-    })
-#endif
-
 #define NVQ_WARN(fmt, ...)                                   \
     do {                                                     \
         if (in_interrupt()) {                                \


### PR DESCRIPTION
Macro WARN() is defined in Linux header include/asm-generic/bug.h, and
it is not necessary to preserve the outdated defintions since the NVIDIA
Open GPU kernel module supports Linux v3.10+.