### PR TITLE
remove pKernelMIGManager shadow variable definition

### DIFF
--- a/src/nvidia/src/kernel/gpu/ce/kernel_ce.c
+++ b/src/nvidia/src/kernel/gpu/ce/kernel_ce.c
@@ -188,9 +188,9 @@ subdeviceCtrlCmdCeGetAllCaps_IMPL
 
     if (IS_MIG_IN_USE(pGpu))
     {
-        KernelMIGManager *pKernelMIGManager = GPU_GET_KERNEL_MIG_MANAGER(pGpu);
         NvHandle hClient = RES_GET_CLIENT_HANDLE(pSubdevice);
 
+        pKernelMIGManager = GPU_GET_KERNEL_MIG_MANAGER(pGpu);
         NV_CHECK_OK_OR_RETURN(
             LEVEL_ERROR,
             kmigmgrGetInstanceRefFromClient(pGpu, pKernelMIGManager,


### PR DESCRIPTION
pKernelMIGManager is defined in two scopes within the
subdeviceCtrlCmdCeGetAllCaps_IMPL() function.  When the second one
goes out of scope, pKernelMigManager is NULL.  pKernelMigManager
is needed in the later call to subdeviceCtrlCmdCeGetAllCaps_IMPL()
so remove the second definition and use the first, function level
definition.

Signed-off-by: Tom Rix <trix@redhat.com>