### PR TITLE
Fix device null pointer deref and add acpi bus query failure check

### DIFF
--- a/kernel-open/nvidia/nv-acpi.c
+++ b/kernel-open/nvidia/nv-acpi.c
@@ -717,6 +717,7 @@ acpi_status nv_acpi_find_methods(
 
 void NV_API_CALL nv_acpi_methods_uninit(void)
 {
+    acpi_status status;
     struct acpi_device *device = NULL;
 
     nvif_handle = NULL;
@@ -737,13 +738,13 @@ void NV_API_CALL nv_acpi_methods_uninit(void)
 #if defined(NV_ACPI_BUS_GET_DEVICE_PRESENT)
     status = acpi_bus_get_device(nvif_parent_gpu_handle, &device);
 
-    if (ACPI_FAILURE(status) || !device)
-        return;
-
-    nv_uninstall_notifier(device->driver_data, nv_acpi_event);
+    if (!(ACPI_FAILURE(status) || !device)) {
+        nv_uninstall_notifier(device->driver_data, nv_acpi_event);
+    }
 #endif
 
-    device->driver_data = NULL;
+    if (device != NULL)
+        device->driver_data = NULL;
     nvif_parent_gpu_handle = NULL;
 
     return;

--- a/kernel-open/nvidia/nv-acpi.c
+++ b/kernel-open/nvidia/nv-acpi.c
@@ -735,7 +735,10 @@ void NV_API_CALL nv_acpi_methods_uninit(void)
         return;
 
 #if defined(NV_ACPI_BUS_GET_DEVICE_PRESENT)
-    acpi_bus_get_device(nvif_parent_gpu_handle, &device);
+    status = acpi_bus_get_device(nvif_parent_gpu_handle, &device);
+
+    if (ACPI_FAILURE(status) || !device)
+        return;
 
     nv_uninstall_notifier(device->driver_data, nv_acpi_event);
 #endif


### PR DESCRIPTION
Makes use of `ACPI_FAILURE` macro to check successful operation of `acpi_bus_get_device`, and adds a null check before using the contents of `device`.

Fixes: #109 

_note: functional change, followup from PR #22_ 