### PR TITLE
always clear numPagesAlloc

### DIFF
--- a/src/nvidia/src/kernel/gpu/mem_mgr/phys_mem_allocator/addrtree.c
+++ b/src/nvidia/src/kernel/gpu/mem_mgr/phys_mem_allocator/addrtree.c
@@ -848,6 +848,8 @@ _pmaAddrtreeScanContiguous
     // This requirement is ensured in PMA
     NV_ASSERT(alignment >= pageSize && portUtilIsPowerOfTwo(alignment));
 
+    *numPagesAlloc = 0;
+
     // Only focus on the level above the pageSize level. Children are ignored.
     level = addrtreeGetTreeLevel(pageSize);
     if (level == 0)
@@ -884,8 +886,6 @@ _pmaAddrtreeScanContiguous
         *numPagesAlloc = numPages;
         return NV_OK;
     }
-
-    *numPagesAlloc = 0;
 
     if (bSkipEvict)
     {


### PR DESCRIPTION
Clang static analysis on RHEL reports this issue
addrtree.c:1154:50: warning: The left operand of '/' is a garbage value [core.UndefinedBinaryOperatorResult]
  *numPagesAlloc += localNumPagesAlloc / 2;
                    ~~~~~~~~~~~~~~~~~~ ^

_pmaAddrtreeScanContiguous() can return early with an error without
setting numPagesAlloc.  There are several uses of
_pmaAddrtreeScanCantiguous() that do not check the status and
depend on the setting of of numPageAlloc as a side effect.

To ensure the side effect is always valid, move the clearing
of numPagesAlloc to before the early exit

Signed-off-by: Tom Rix <trix@redhat.com>