### PR TITLE
Fix null pointer derefs in src/nvidia-modeset and src/common/nvlink

### DIFF
--- a/src/common/nvlink/kernel/nvlink/core/nvlink_conn_mgmt.c
+++ b/src/common/nvlink/kernel/nvlink/core/nvlink_conn_mgmt.c
@@ -44,7 +44,7 @@ nvlink_core_get_intranode_conn
 
     FOR_EACH_CONNECTION(tmpConn, nvlinkLibCtx.nv_intraconn_head, node)
     {
-        if (tmpConn->end0 == endpoint || tmpConn->end1 == endpoint)
+        if (tmpConn != NULL && (tmpConn->end0 == endpoint || tmpConn->end1 == endpoint))
         {
             *conn = tmpConn;
             break;
@@ -69,7 +69,7 @@ nvlink_core_get_internode_conn
 
     FOR_EACH_CONNECTION(tmpConn, nvlinkLibCtx.nv_interconn_head, node)
     {
-        if (tmpConn->local_end == localLink)
+        if (tmpConn != NULL && tmpConn->local_end == localLink)
         {
             *conn = tmpConn;
             break;

--- a/src/common/nvlink/kernel/nvlink/core/nvlink_discovery.c
+++ b/src/common/nvlink/kernel/nvlink/core/nvlink_discovery.c
@@ -131,6 +131,10 @@ _nvlink_core_discover_topology(void)
     {
         FOR_EACH_LINK_REGISTERED(end0, dev0, node)
         {
+            if(!end0)
+            {
+                continue;
+            }
             //
             // If receiver detect failed for the link or if clocks could not be set
             // up for the link, then move to next link

--- a/src/common/nvlink/kernel/nvlink/core/nvlink_ioctl.c
+++ b/src/common/nvlink/kernel/nvlink/core/nvlink_ioctl.c
@@ -248,7 +248,10 @@ _nvlink_core_get_enabled_link_mask
 
     nvListForEachEntry(link, &dev->link_list, node)
     {
-        linkMask |= NVBIT64(link->linkNumber);
+        if(link != NULL)
+        {
+            linkMask |= NVBIT64(link->linkNumber);
+        }
     }
 
     return linkMask;
@@ -346,6 +349,11 @@ nvlink_core_get_device_by_devinfo
 
     FOR_EACH_DEVICE_REGISTERED(tmpDev, nvlinkLibCtx.nv_devicelist_head, node)
     {
+        if(!tmpDev)
+        {
+            continue;
+        }
+
         if ( (tmpDev->nodeId           == devInfo->nodeId)         &&
              (tmpDev->pciInfo.domain   == devInfo->pciInfo.domain) &&
              (tmpDev->pciInfo.bus      == devInfo->pciInfo.bus)    &&
@@ -379,6 +387,11 @@ nvlink_core_get_link_by_endpoint
 
     FOR_EACH_DEVICE_REGISTERED(tmpDev, nvlinkLibCtx.nv_devicelist_head, node)
     {
+        if(!tmpDev)
+        {
+            continue;
+        }
+
         if ((tmpDev->nodeId           == endPoint->nodeId)         &&
             (tmpDev->pciInfo.domain   == endPoint->pciInfo.domain) &&
             (tmpDev->pciInfo.bus      == endPoint->pciInfo.bus)    &&
@@ -387,6 +400,11 @@ nvlink_core_get_link_by_endpoint
         {
             FOR_EACH_LINK_REGISTERED(tmpLink, tmpDev, node)
             {
+                if(!tmpLink)
+                {
+                    continue;
+                }
+                
                 if (tmpLink->linkNumber == endPoint->linkIndex)
                 {
                     *link = tmpLink;

--- a/src/common/nvlink/kernel/nvlink/interface/nvlink_kern_registration_entry.c
+++ b/src/common/nvlink/kernel/nvlink/interface/nvlink_kern_registration_entry.c
@@ -470,6 +470,11 @@ _nvlink_lib_is_device_registered
 
     FOR_EACH_DEVICE_REGISTERED(tmpDev, nvlinkLibCtx.nv_devicelist_head, node)
     {
+        if(!dev)
+        {
+            continue;
+        }
+
         if (dev->deviceId == tmpDev->deviceId)
         {
             return NV_TRUE;
@@ -498,6 +503,11 @@ _nvlink_lib_is_link_registered
 
     FOR_EACH_LINK_REGISTERED(tmpLink, dev, node)
     {
+        if(!link)
+        {
+            continue;
+        }
+
         if (link->linkId == tmpLink->linkId)
         {
             return NV_TRUE;

--- a/src/nvidia-modeset/src/dp/nvdp-connector.cpp
+++ b/src/nvidia-modeset/src/dp/nvdp-connector.cpp
@@ -573,6 +573,10 @@ void NotifyAttachBegin(NVDPLibConnectorPtr pDpLibConnector,
     /* Insert active dpys into group */
     pDpLibConnector->dpyIdList[head] = pDpLibModesetState->dpyIdList;
     FOR_ALL_EVO_DPYS(pDpyEvo, pDpLibConnector->dpyIdList[head], pDispEvo) {
+        if(!pDpyEvo)
+        {
+            continue;
+        }
         if (pDpyEvo->dp.pDpLibDevice) {
             pDpLibConnector->pGroup[head]->insert(
                     pDpyEvo->dp.pDpLibDevice->device);

--- a/src/nvidia/src/kernel/gpu/perf/kern_perf_gpuboostsync.c
+++ b/src/nvidia/src/kernel/gpu/perf/kern_perf_gpuboostsync.c
@@ -247,6 +247,11 @@ kperfDoSyncGpuBoostLimits_IMPL
         {
             RM_API *pRmApi = GPU_GET_PHYSICAL_RMAPI(pGpu);
 
+            if(!pGpuItr)
+            {
+                continue;
+            }
+            
             status = pRmApi->Control(pRmApi,
                                      pGpuItr->hInternalClient,
                                      pGpuItr->hInternalSubdevice,


### PR DESCRIPTION
Added null checks to avoid undefined behaviour caused by potential null pointer dereferences at runtime.