### PR TITLE
Add Objective-C class to nvidia-drm

### DIFF
--- a/kernel-open/nvidia-drm/nvidia-drm.h
+++ b/kernel-open/nvidia-drm/nvidia-drm.h
@@ -25,6 +25,20 @@
 
 #include "nvidia-drm-conftest.h"
 
+#ifdef __clang__
+#define NS_ROOT_CLASS __attribute__((objc_root_class))
+#else
+#define NS_ROOT_CLASS
+#endif
+
+NS_ROOT_CLASS
+@interface NvDRM {}
+
++ (int)nvDrmInit;
++ (void)nvDrmExit;
+
+@end
+
 int nv_drm_init(void);
 void nv_drm_exit(void);
 

--- a/kernel-open/nvidia-drm/nvidia-drm.m
+++ b/kernel-open/nvidia-drm/nvidia-drm.m
@@ -20,7 +20,7 @@
  * DEALINGS IN THE SOFTWARE.
  */
 
-#include "nvidia-drm.h"
+#import "nvidia-drm.h"
 
 #if defined(NV_DRM_AVAILABLE)
 
@@ -35,8 +35,10 @@ const struct NvKmsKapiFunctionsTable* const nvKms = &nvKmsFuncsTable;
 
 #endif
 
-int nv_drm_init(void)
-{
+
+@implementation NvDRM
+
++ (int)nvDrmInit {
 #if defined(NV_DRM_AVAILABLE)
     if (!nvKmsKapiGetFunctionsTable(&nvKmsFuncsTable)) {
         NV_DRM_LOG_ERR(
@@ -51,9 +53,21 @@ int nv_drm_init(void)
 #endif
 }
 
-void nv_drm_exit(void)
-{
++ (void)nvDrmExit {
 #if defined(NV_DRM_AVAILABLE)
     nv_drm_remove_devices();
 #endif
+}
+
+@end
+
+
+int nv_drm_init(void)
+{
+    [NvDRM nvDrmInit];
+}
+
+void nv_drm_exit(void)
+{
+    [NvDRM nvDrmExit];
 }


### PR DESCRIPTION
I heard from some guy that Objective-C is better than C for writing drivers. So I added an objective C class because it makes the driver better .