### PR TITLE
DRAFT: uvm push uapi

### DIFF
--- a/kernel-open/nvidia-uvm/uvm.c
+++ b/kernel-open/nvidia-uvm/uvm.c
@@ -939,6 +939,7 @@ static long uvm_ioctl(struct file *filp, unsigned int cmd, unsigned long arg)
         UVM_ROUTE_CMD_STACK_INIT_CHECK(UVM_CLEAN_UP_ZOMBIE_RESOURCES,      uvm_api_clean_up_zombie_resources);
         UVM_ROUTE_CMD_STACK_INIT_CHECK(UVM_POPULATE_PAGEABLE,              uvm_api_populate_pageable);
         UVM_ROUTE_CMD_STACK_INIT_CHECK(UVM_VALIDATE_VA_RANGE,              uvm_api_validate_va_range);
+        UVM_ROUTE_CMD_STACK_INIT_CHECK(UVM_CHANNEL_PUSH,                   uvm_api_channel_push);
     }
 
     // Try the test ioctls if none of the above matched

--- a/kernel-open/nvidia-uvm/uvm_api.h
+++ b/kernel-open/nvidia-uvm/uvm_api.h
@@ -252,5 +252,6 @@ NV_STATUS uvm_api_unmap_external(UVM_UNMAP_EXTERNAL_PARAMS *params, struct file 
 NV_STATUS uvm_api_migrate_range_group(UVM_MIGRATE_RANGE_GROUP_PARAMS *params, struct file *filp);
 NV_STATUS uvm_api_alloc_semaphore_pool(UVM_ALLOC_SEMAPHORE_POOL_PARAMS *params, struct file *filp);
 NV_STATUS uvm_api_populate_pageable(const UVM_POPULATE_PAGEABLE_PARAMS *params, struct file *filp);
+NV_STATUS uvm_api_channel_push(UVM_CHANNEL_PUSH_PARAMS *params, struct file *filp);
 
 #endif // __UVM_API_H__

--- a/kernel-open/nvidia-uvm/uvm_channel.c
+++ b/kernel-open/nvidia-uvm/uvm_channel.c
@@ -335,6 +335,24 @@ NV_STATUS uvm_channel_begin_push(uvm_channel_t *channel, uvm_push_t *push)
     return NV_OK;
 }
 
+NV_STATUS uvm_api_channel_push(UVM_CHANNEL_PUSH_PARAMS *params, struct file *filp)
+{
+    uvm_channel_t *channel = (uvm_channel_t *)filp->private_data;
+    int i; /* Im pretty sure that C90 needs this */
+    uvm_push_t push;
+
+    uvm_channel_begin_push(channel, &push);
+    push.next[0] = UVM_METHOD_INC(params->subch, params->a[0], params->count);
+    ++push.next;
+    for (i = 0; i < params->count; i++) {
+        push.next[0] = params->d[i];
+        ++push.next;
+    }
+    uvm_channel_end_push(&push);
+
+    return NV_OK;
+}
+
 static void internal_channel_submit_work(uvm_push_t *push, NvU32 push_size, NvU32 new_gpu_put)
 {
     NvU64 *gpfifo_entry;

--- a/kernel-open/nvidia-uvm/uvm_ioctl.h
+++ b/kernel-open/nvidia-uvm/uvm_ioctl.h
@@ -1065,6 +1065,15 @@ typedef struct
     NV_STATUS rmStatus;     // OUT
 } UVM_IS_8_SUPPORTED_PARAMS;
 
+#define UVM_CHANNEL_PUSH                                              UVM_IOCTL_BASE(75)
+typedef struct
+{
+    NV_STATUS       rmStatus;                        // OUT
+    unsigned        subch;
+    unsigned        count;
+    unsigned        a[6];
+    unsigned        d[6];
+} UVM_CHANNEL_PUSH_PARAMS;
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
This is an _experimental_ uapi for exposing the pushbuffer to userspace through ioctl. This needs to have error checking/pushbuf validation, and support for pushes with a size greater than 6 before it can be merged.

Im not going to _really_ do much with this until I need to use it.