### PR TITLE
Introduce NV_KZALLOC macro

### DIFF
--- a/kernel-open/common/inc/nv-linux.h
+++ b/kernel-open/common/inc/nv-linux.h
@@ -605,6 +605,13 @@ static NvBool nv_numa_node_has_memory(int node_id)
             NV_MEMDBG_ADD(ptr, size); \
     }
 
+#define NV_KZALLOC(ptr, size) \
+    { \
+        (ptr) = kzalloc(size, NV_GFP_KERNEL); \
+        if (ptr) \
+            NV_MEMDBG_ADD(ptr, size); \
+    }
+
 #define NV_KMALLOC_ATOMIC(ptr, size) \
     { \
         (ptr) = kmalloc(size, NV_GFP_ATOMIC); \

--- a/kernel-open/nvidia/nv-dmabuf.c
+++ b/kernel-open/nvidia/nv-dmabuf.c
@@ -79,23 +79,19 @@ nv_dma_buf_alloc_file_private(
 {
     nv_dma_buf_file_private_t *priv = NULL;
 
-    NV_KMALLOC(priv, sizeof(nv_dma_buf_file_private_t));
+    NV_KZALLOC(priv, sizeof(nv_dma_buf_file_private_t));
     if (priv == NULL)
     {
         return NULL;
     }
 
-    memset(priv, 0, sizeof(nv_dma_buf_file_private_t));
-
     mutex_init(&priv->lock);
 
-    NV_KMALLOC(priv->handles, num_handles * sizeof(priv->handles[0]));
+    NV_KZALLOC(priv->handles, num_handles * sizeof(priv->handles[0]));
     if (priv->handles == NULL)
     {
         goto failed;
     }
-
-    memset(priv->handles, 0, num_handles * sizeof(priv->handles[0]));
 
     return priv;
 
@@ -354,13 +350,11 @@ nv_dma_buf_map(
         goto unlock_api_lock;
     }
 
-    NV_KMALLOC(sgt, sizeof(struct sg_table));
+    NV_KZALLOC(sgt, sizeof(struct sg_table));
     if (sgt == NULL)
     {
         goto unlock_gpu_lock;
     }
-
-    memset(sgt, 0, sizeof(struct sg_table));
 
     //
     // RM currently returns contiguous BAR1, so we create as many

--- a/kernel-open/nvidia/nv-msi.c
+++ b/kernel-open/nvidia/nv-msi.c
@@ -36,7 +36,7 @@ void NV_API_CALL nv_init_msi(nv_state_t *nv)
         nv->interrupt_line = nvl->pci_dev->irq;
         nv->flags |= NV_FLAG_USES_MSI;
         nvl->num_intr = 1;
-        NV_KMALLOC(nvl->irq_count, sizeof(nv_irq_count_info_t) * nvl->num_intr);
+        NV_KZALLOC(nvl->irq_count, sizeof(nv_irq_count_info_t) * nvl->num_intr);
 
         if (nvl->irq_count == NULL)
         {
@@ -47,7 +47,6 @@ void NV_API_CALL nv_init_msi(nv_state_t *nv)
         }
         else
         {
-            memset(nvl->irq_count, 0,  sizeof(nv_irq_count_info_t) * nvl->num_intr);
             nvl->current_num_irq_tracked = 0;
         }
     }
@@ -100,7 +99,7 @@ void NV_API_CALL nv_init_msix(nv_state_t *nv)
         msix_entries->entry = i;
     }
 
-    NV_KMALLOC(nvl->irq_count, sizeof(nv_irq_count_info_t) * num_intr);
+    NV_KZALLOC(nvl->irq_count, sizeof(nv_irq_count_info_t) * num_intr);
 
     if (nvl->irq_count == NULL)
     {
@@ -109,7 +108,6 @@ void NV_API_CALL nv_init_msix(nv_state_t *nv)
     }
     else
     {
-        memset(nvl->irq_count, 0,  sizeof(nv_irq_count_info_t) * num_intr);
         nvl->current_num_irq_tracked = 0;
     }
     rc = nv_pci_enable_msix(nvl, num_intr);

--- a/kernel-open/nvidia/nv-pci.c
+++ b/kernel-open/nvidia/nv-pci.c
@@ -434,14 +434,12 @@ next_bar:
         goto failed;
     }
 
-    NV_KMALLOC(nvl, sizeof(nv_linux_state_t));
+    NV_KZALLOC(nvl, sizeof(nv_linux_state_t));
     if (nvl == NULL)
     {
         nv_printf(NV_DBG_ERRORS, "NVRM: failed to allocate memory\n");
         goto err_not_supported;
     }
-
-    os_mem_set(nvl, 0, sizeof(nv_linux_state_t));
 
     nv  = NV_STATE_PTR(nvl);
 

--- a/kernel-open/nvidia/nv-procfs.c
+++ b/kernel-open/nvidia/nv-procfs.c
@@ -288,13 +288,12 @@ nv_procfs_open_file(
     nv_procfs_private_t *nvpp = NULL;
     nvidia_stack_t *sp = NULL;
 
-    NV_KMALLOC(nvpp, sizeof(nv_procfs_private_t));
+    NV_KZALLOC(nvpp, sizeof(nv_procfs_private_t));
     if (nvpp == NULL)
     {
         nv_printf(NV_DBG_ERRORS, "NVRM: failed to allocate procfs private!\n");
         return -ENOMEM;
     }
-    memset(nvpp, 0, sizeof(*nvpp));
 
     NV_INIT_MUTEX(&nvpp->sp_lock);
 

--- a/kernel-open/nvidia/nv.c
+++ b/kernel-open/nvidia/nv.c
@@ -290,14 +290,12 @@ nv_alloc_t *nvos_create_alloc(
     nv_alloc_t *at;
     unsigned int pt_size, i;
 
-    NV_KMALLOC(at, sizeof(nv_alloc_t));
+    NV_KZALLOC(at, sizeof(nv_alloc_t));
     if (at == NULL)
     {
         nv_printf(NV_DBG_ERRORS, "NVRM: failed to allocate alloc info\n");
         return NULL;
     }
-
-    memset(at, 0, sizeof(nv_alloc_t));
 
     at->dev = dev;
     pt_size = num_pages *  sizeof(nvidia_pte_t *);
@@ -919,11 +917,9 @@ static void *nv_alloc_file_private(void)
     nv_linux_file_private_t *nvlfp;
     unsigned int i;
 
-    NV_KMALLOC(nvlfp, sizeof(nv_linux_file_private_t));
+    NV_KZALLOC(nvlfp, sizeof(nv_linux_file_private_t));
     if (!nvlfp)
         return NULL;
-
-    memset(nvlfp, 0, sizeof(nv_linux_file_private_t));
 
     for (i = 0; i < NV_FOPS_STACK_INDEX_COUNT; ++i)
     {


### PR DESCRIPTION
The pattern of
  p = kmalloc(...);
  memset(p, 0, ...);

Can be reduced to
  p = kzalloc(...)

So introduce and use NV_KZALLOC, a macro that wraps kzalloc.

Signed-off-by: Tom Rix <trix@redhat>