### PR TITLE
Add missing include to fix 6.0-rc1 build

### DIFF
--- a/kernel-open/nvidia-drm/nvidia-drm-helper.h
+++ b/kernel-open/nvidia-drm/nvidia-drm-helper.h
@@ -108,6 +108,7 @@ nv_drm_prime_pages_to_sg(struct drm_device *dev,
  * OTHER DEALINGS IN THE SOFTWARE.
  */
 #include <drm/drm_crtc.h>
+#include <drm/drm_framebuffer.h>
 
 #if defined(drm_for_each_plane)
 #define nv_drm_for_each_plane(plane, dev) \


### PR DESCRIPTION
https://github.com/torvalds/linux/commit/720cf96d8fecde29b72e1101f8a567a0ce99594f
Upstream removed drm_framebuffer.h from drm_crtc.h which cause drm_framebuffer_get function not found in dkms build