### PR TITLE
remove unneeded, nested if statement

### DIFF
--- a/src/common/unix/common/utils/unix_rm_handle.c
+++ b/src/common/unix/common/utils/unix_rm_handle.c
@@ -200,11 +200,10 @@ NvU32 nvGenerateUnixRmHandleInternal(NVUnixRmHandleAllocatorPtr pAllocator)
         handleId++;
     }
 
-    if (handleId > pAllocator->maxHandles) {
-        if (!UnixRmHandleReallocBitmap(pAllocator, pAllocator->maxHandles * 2)) {
-            nvUnixRmHandleAssert(!"Failed to grow RM handle allocator bitmap");
-            return INVALID_HANDLE;
-        }
+    if ((handleId > pAllocator->maxHandles) && 
+        (!UnixRmHandleReallocBitmap(pAllocator, pAllocator->maxHandles * 2))) {
+        nvUnixRmHandleAssert(!"Failed to grow RM handle allocator bitmap");
+        return INVALID_HANDLE;
     }
 
     nvUnixRmHandleAssert(!USED(pAllocator->bitmap, handleId));


### PR DESCRIPTION
Double if can be replaced with refactored condition, increasing clarity.