### PR TITLE
Set INSTALL_MOD_DIR only if it's not defined

### DIFF
--- a/kernel-open/Makefile
+++ b/kernel-open/Makefile
@@ -65,6 +65,7 @@ else
                                     $(NV_KERNEL_MODULES))
   NV_VERBOSE ?=
   SPECTRE_V2_RETPOLINE ?= 0
+  INSTALL_MOD_DIR ?= kernel/drivers/video
 
   ifeq ($(NV_VERBOSE),1)
     KBUILD_PARAMS += V=1
@@ -74,7 +75,7 @@ else
   KBUILD_PARAMS += NV_KERNEL_SOURCES=$(KERNEL_SOURCES)
   KBUILD_PARAMS += NV_KERNEL_OUTPUT=$(KERNEL_OUTPUT)
   KBUILD_PARAMS += NV_KERNEL_MODULES="$(NV_KERNEL_MODULES)"
-  KBUILD_PARAMS += INSTALL_MOD_DIR=kernel/drivers/video
+  KBUILD_PARAMS += INSTALL_MOD_DIR="$(INSTALL_MOD_DIR)"
   KBUILD_PARAMS += NV_SPECTRE_V2=$(SPECTRE_V2_RETPOLINE)
 
   .PHONY: modules module clean clean_conftest modules_install


### PR DESCRIPTION
As described in [Compiling the Kernel (Kernel 5.15)](https://developer.nvidia.com/docs/drive/drive-os/6.0.8.1/public/drive-os-linux-sdk/common/topics/sys_programming/compiling_the_kernel_linux.html) section of `NVIDIA DRIVE OS Linux SDK Developer Guide` v6.0.8.1, `nvidia*.ko` are copied into `extra/opensrc-disp` manually:
```
mkdir -p $NV_WORKSPACE/drive-linux/kernel/source/oss_src/out-linux/lib/modules/<kernel_version>/extra/opensrc-disp/
cd kernel-open
cp nvidia.ko nvidia-modeset.ko nvidia-drm.ko $NV_WORKSPACE/drive-linux/kernel/source/oss_src/out-linux/lib/modules/<kernel_version>/extra/opensrc-disp/
```
So, the `INSTALL_MOD_DIR` should be set to `extra/opensrc-disp` at least in DriveOS 6.0.8.1 if `make make modules_install` is used instead of copying them manually.

But in `kernel-open/Makefile`,  `INSTALL_MOD_DIR` is set to `kernel/drivers/video` forcefully.
So `INSTALL_MOD_DIR` should be set only if it's not specified, such as `INSTALL_MOD_DIR=extra/opensrc-disp make modules_install` should works if users want to install them into another directory.