### PR TITLE
Makefile: Use $(MODLIB)/build/source symlink for kernel source

### DIFF
--- a/kernel-open/Makefile
+++ b/kernel-open/Makefile
@@ -28,7 +28,7 @@ else
   else
     KERNEL_UNAME ?= $(shell uname -r)
     KERNEL_MODLIB := /lib/modules/$(KERNEL_UNAME)
-    KERNEL_SOURCES := $(shell test -d $(KERNEL_MODLIB)/source && echo $(KERNEL_MODLIB)/source || echo $(KERNEL_MODLIB)/build)
+    KERNEL_SOURCES := $(shell test -d $(KERNEL_MODLIB)/source && echo $(KERNEL_MODLIB)/source || $(shell test -d $(KERNEL_MODLIB)/build/source && echo $(KERNEL_MODLIB)/build/source || echo $(KERNEL_MODLIB)/build)
   endif
 
   KERNEL_OUTPUT := $(KERNEL_SOURCES)
@@ -43,6 +43,10 @@ else
     KERNEL_UNAME ?= $(shell uname -r)
     KERNEL_MODLIB := /lib/modules/$(KERNEL_UNAME)
     ifeq ($(KERNEL_SOURCES), $(KERNEL_MODLIB)/source)
+      KERNEL_OUTPUT := $(KERNEL_MODLIB)/build
+      KBUILD_PARAMS := KBUILD_OUTPUT=$(KERNEL_OUTPUT)
+    endif
+    ifeq ($(KERNEL_SOURCES), $(KERNEL_MODLIB)/build/source)
       KERNEL_OUTPUT := $(KERNEL_MODLIB)/build
       KBUILD_PARAMS := KBUILD_OUTPUT=$(KERNEL_OUTPUT)
     endif


### PR DESCRIPTION
After kernel commit d8131c2965d5ee59bfa4d548641e52a13cbe17c9 ("kbuild: remove $(MODLIB)/source symlink") https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=d8131c2965d5ee59bfa4d548641e52a13cbe17c9 $(MODLIB)/source no longer exists.  Add support for $(MODLIB)/build/source.