### PR TITLE
Changed calls of crypto_tfm_ctx_aligned due to it's exclusion in kernels 6.7.0 or above

### DIFF
--- a/kernel-open/nvidia/internal_crypt_lib.h
+++ b/kernel-open/nvidia/internal_crypt_lib.h
@@ -68,7 +68,6 @@
 #endif
 
 #ifdef USE_LKCA
-#include <linux/version.h>
 #include <linux/crypto.h>
 #include <linux/scatterlist.h>
 #include <crypto/aead.h>
@@ -80,15 +79,6 @@
 // This value is accurate as of 6.1
 #ifndef HASH_MAX_DIGESTSIZE
 #define HASH_MAX_DIGESTSIZE 64
-#endif
-
-// crypto_tfm_ctx_aligned got removed in 6.7
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 7, 0)
-// Code copied include/crypto/algapi.h from 6.6
-static inline void *crypto_tfm_ctx_aligned(struct crypto_tfm *tfm)
-{
-	return crypto_tfm_ctx_align(tfm, crypto_tfm_alg_alignmask(tfm) + 1);
-}
 #endif
 
 #else

--- a/kernel-open/nvidia/internal_crypt_lib.h
+++ b/kernel-open/nvidia/internal_crypt_lib.h
@@ -68,6 +68,7 @@
 #endif
 
 #ifdef USE_LKCA
+#include <linux/version.h>
 #include <linux/crypto.h>
 #include <linux/scatterlist.h>
 #include <crypto/aead.h>
@@ -79,6 +80,15 @@
 // This value is accurate as of 6.1
 #ifndef HASH_MAX_DIGESTSIZE
 #define HASH_MAX_DIGESTSIZE 64
+#endif
+
+// crypto_tfm_ctx_aligned got removed in 6.7
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 7, 0)
+// Code copied include/crypto/algapi.h from 6.6
+static inline void *crypto_tfm_ctx_aligned(struct crypto_tfm *tfm)
+{
+	return crypto_tfm_ctx_align(tfm, crypto_tfm_alg_alignmask(tfm) + 1);
+}
 #endif
 
 #else

--- a/kernel-open/nvidia/libspdm_shash.c
+++ b/kernel-open/nvidia/libspdm_shash.c
@@ -87,8 +87,8 @@ bool lkca_hmac_duplicate(struct shash_desc *dst, struct shash_desc const *src)
 
         struct crypto_shash *src_tfm = src->tfm;
         struct crypto_shash *dst_tfm = dst->tfm;
-        char *src_ipad = crypto_tfm_ctx_aligned(&src_tfm->base);
-        char *dst_ipad = crypto_tfm_ctx_aligned(&dst_tfm->base);
+        char *src_ipad = crypto_tfm_ctx_align(&src_tfm->base, crypto_tfm_alg_alignmask(&src_tfm->base) + 1);
+        char *dst_ipad = crypto_tfm_ctx_align(&dst_tfm->base, crypto_tfm_alg_alignmask(&dst_tfm->base) + 1);
         int ss = crypto_shash_statesize(dst_tfm);
         memcpy(dst_ipad, src_ipad, crypto_shash_blocksize(src->tfm));
         memcpy(dst_ipad + ss, src_ipad + ss, crypto_shash_blocksize(src->tfm));


### PR DESCRIPTION
Since crypto_tfm_ctx_aligned got removed in kernel 6.7.0 (https://github.com/torvalds/linux/commit/acd7799574e57f1e494a5b85741eee78d1e93aca), we need to add it back in (or change the two uses of it) to be able to compile with newer kernels. 

Fixes issue: #574

Edit: Instead of re implementing (like my first commit) a better solution is to change the calls of crypt_ftm_ctx_aligned into doing what crypto_ftm_ctx_aligned used to do, that way this solution doesn't relay on conditional compilation and is backwards compatible. 