### PR TITLE
kernel-open/conftest.sh: fix non-portable usage of tr

### DIFF
--- a/kernel-open/conftest.sh
+++ b/kernel-open/conftest.sh
@@ -71,7 +71,8 @@ test_header_presence() {
     TEST_CFLAGS="-E -M $CFLAGS"
 
     file="$1"
-    file_define=NV_`echo $file | tr '/.\-a-z' '___A-Z'`_PRESENT
+    # Replace '.', '/', '-' with '_'
+    file_define=NV_`echo $file | awk '{ gsub(/\.|\/|-/, "_", $1); print toupper($0) }'`_PRESENT
 
     CODE="#include <$file>"
 


### PR DESCRIPTION
Closes #468 

Replaces unportable `tr` usage with an equivalent `awk` command. Tested it by running it on the inputs generated by the script:

```sh
$ tr '/.\-a-z' '___A-Z' < headers | sha256sum # GNU tr, not Busybox
db7d5442f53eaadf3f838b3e2392e2563cae4742b7b74497d72eff6c425bc2f0  -
$ awk '{ gsub(/\.|\/|-/, "_", $1); print toupper($0) }' < headers | sha256sum
db7d5442f53eaadf3f838b3e2392e2563cae4742b7b74497d72eff6c425bc2f0  -
```

```c
asm/system.h
drm/drm_auth.h
drm/drm_gem.h
drm/drmP.h
drm/drm_aperture.h
drm/drm_crtc.h
drm/drm_color_mgmt.h
drm/drm_atomic.h
drm/drm_atomic_helper.h
drm/drm_atomic_state_helper.h
drm/drm_encoder.h
drm/drm_atomic_uapi.h
drm/drm_drv.h
drm/drm_fbdev_generic.h
drm/drm_framebuffer.h
drm/drm_connector.h
drm/drm_probe_helper.h
drm/drm_blend.h
drm/drm_fourcc.h
drm/drm_prime.h
drm/drm_plane.h
drm/drm_vblank.h
drm/drm_file.h
drm/drm_ioctl.h
drm/drm_device.h
drm/drm_mode_config.h
drm/drm_modeset_lock.h
dt-bindings/interconnect/tegra_icc_id.h
generated/autoconf.h
generated/compile.h
generated/utsrelease.h
linux/efi.h
linux/kconfig.h
linux/platform/tegra/mc_utils.h
linux/printk.h
linux/ratelimit.h
linux/log2.h
linux/prio_tree.h
linux/of.h
linux/bug.h
linux/sched.h
linux/sched/mm.h
linux/sched/signal.h
linux/sched/task.h
xen/ioemu.h
linux/sched/task_stack.h
linux/fence.h
linux/dma-fence.h
linux/dma-resv.h
soc/tegra/fuse.h
soc/tegra/chip-id.h
soc/tegra/tegra_bpmp.h
video/nv_internal.h
linux/platform/tegra/dce/dce-client-ipc.h
linux/nvhost.h
linux/nvhost_t194.h
linux/host1x-next.h
asm/book3s/64/hash-64k.h
asm/set_memory.h
asm/prom.h
asm/powernv.h
linux/atomic.h
asm/barrier.h
asm/opal-api.h
sound/hdaudio.h
asm/pgtable_types.h
asm/page.h
linux/stringhash.h
linux/dma-map-ops.h
rdma/peer_mem.h
sound/hda_codec.h
linux/dma-buf.h
linux/time.h
linux/platform_device.h
linux/mutex.h
linux/of_device.h
linux/reset.h
linux/of_platform.h
linux/of_gpio.h
linux/gpio.h
linux/gpio/consumer.h
linux/interconnect.h
linux/pm_runtime.h
linux/clk.h
linux/clk-provider.h
linux/ioasid.h
linux/stdarg.h
linux/iosys-map.h
asm/coco.h
linux/vfio_pci_core.h
linux/mdev.h
soc/tegra/bpmp-abi.h
soc/tegra/bpmp.h
linux/sync_file.h
linux/cc_platform.h
asm/cpufeature.h
linux/mpi.h
```