### PR TITLE
Patches for testing r555 stutter issues

### DIFF
--- a/kernel-open/nvidia/nv.c
+++ b/kernel-open/nvidia/nv.c
@@ -4042,6 +4042,16 @@ int NV_API_CALL nv_get_event(
     nvidia_event_t *nvet;
     unsigned long eflags;
 
+    //
+    // Note that the head read/write is not atomic when done outside of the
+    // spinlock, so this might not be a valid pointer at all. But if we read
+    // NULL here that means that the value indeed was NULL and we can bail
+    // early since there's no events. Otherwise, we have to do a proper read
+    // under a spinlock.
+    //
+    if (nvlfp->event_data_head == NULL)
+        return NV_ERR_GENERIC;
+
     NV_SPIN_LOCK_IRQSAVE(&nvlfp->fp_lock, eflags);
 
     nvet = nvlfp->event_data_head;

--- a/src/common/sdk/nvidia/inc/nvdump.h
+++ b/src/common/sdk/nvidia/inc/nvdump.h
@@ -79,6 +79,7 @@ typedef enum
     NVDUMP_COMPONENT_ENG_GSP,
     NVDUMP_COMPONENT_ENG_INFOROM,
     NVDUMP_COMPONENT_ENG_GCX,
+    NVDUMP_COMPONENT_ENG_KGSP,
     // The following components are global to the system:
     NVDUMP_COMPONENT_SYS_RCDB = 0x400,
     NVDUMP_COMPONENT_SYS_SYSINFO,

--- a/src/nvidia/arch/nvalloc/unix/include/osapi.h
+++ b/src/nvidia/arch/nvalloc/unix/include/osapi.h
@@ -121,9 +121,6 @@ NvBool     RmGpuHasIOSpaceEnabled (nv_state_t *);
 void       RmFreeUnusedClients    (nv_state_t *, nv_file_private_t *);
 NV_STATUS  RmIoctl                (nv_state_t *, nv_file_private_t *, NvU32, void *, NvU32);
 
-NV_STATUS  RmAllocOsEvent         (NvHandle, nv_file_private_t *, NvU32);
-NV_STATUS  RmFreeOsEvent          (NvHandle, NvU32);
-
 void       RmI2cAddGpuPorts(nv_state_t *);
 
 NV_STATUS  RmInitX86EmuState(OBJGPU *);
@@ -141,9 +138,6 @@ int        amd_msr_c0011022_incompatible(OBJOS *);
 
 NV_STATUS  rm_get_adapter_status    (nv_state_t *, NvU32 *);
 
-NV_STATUS  rm_alloc_os_event        (NvHandle, nv_file_private_t *, NvU32);
-NV_STATUS  rm_free_os_event         (NvHandle, NvU32);
-NV_STATUS  rm_get_event_data        (nv_file_private_t *, NvP64, NvU32 *);
 void       rm_client_free_os_events (NvHandle);
 
 NV_STATUS  rm_create_mmap_context   (NvHandle, NvHandle, NvHandle, NvP64, NvU64, NvU64, NvU32, NvU32);

--- a/src/nvidia/arch/nvalloc/unix/src/escape.c
+++ b/src/nvidia/arch/nvalloc/unix/src/escape.c
@@ -677,52 +677,6 @@ NV_STATUS RmIoctl(
             break;
         }
 
-        case NV_ESC_ALLOC_OS_EVENT:
-        {
-            nv_ioctl_alloc_os_event_t *pApi = data;
-
-            if (dataSize != sizeof(nv_ioctl_alloc_os_event_t))
-            {
-                rmStatus = NV_ERR_INVALID_ARGUMENT;
-                goto done;
-            }
-
-            pApi->Status = rm_alloc_os_event(pApi->hClient,
-                                             nvfp,
-                                             pApi->fd);
-            break;
-        }
-
-        case NV_ESC_FREE_OS_EVENT:
-        {
-            nv_ioctl_free_os_event_t *pApi = data;
-
-            if (dataSize != sizeof(nv_ioctl_free_os_event_t))
-            {
-                rmStatus = NV_ERR_INVALID_ARGUMENT;
-                goto done;
-            }
-
-            pApi->Status = rm_free_os_event(pApi->hClient, pApi->fd);
-            break;
-        }
-
-        case NV_ESC_RM_GET_EVENT_DATA:
-        {
-            NVOS41_PARAMETERS *pApi = data;
-
-            if (dataSize != sizeof(NVOS41_PARAMETERS))
-            {
-                rmStatus = NV_ERR_INVALID_ARGUMENT;
-                goto done;
-            }
-
-            pApi->status = rm_get_event_data(nvfp,
-                                             pApi->pEvent,
-                                             &pApi->MoreEvents);
-            break;
-        }
-
         case NV_ESC_STATUS_CODE:
         {
             nv_state_t *pNv;

--- a/src/nvidia/exports_link_command.txt
+++ b/src/nvidia/exports_link_command.txt
@@ -1,6 +1,5 @@
 --undefined=rm_disable_adapter
 --undefined=rm_execute_work_item
---undefined=rm_free_os_event
 --undefined=rm_free_private_state
 --undefined=rm_cleanup_file_private
 --undefined=rm_unbind_lock

--- a/src/nvidia/generated/g_all_dcl_pb.h
+++ b/src/nvidia/generated/g_all_dcl_pb.h
@@ -17,9 +17,9 @@ extern const PRB_MSG_DESC prb_messages_dcl[];
 
 // Message maximum lengths
 // Does not include repeated fields, strings and byte arrays.
-#define DCL_ENGINES_LEN 130
-#define DCL_DCLMSG_LEN 567
-#define DCL_ERRORBLOCK_LEN 571
+#define DCL_ENGINES_LEN 136
+#define DCL_DCLMSG_LEN 573
+#define DCL_ERRORBLOCK_LEN 577
 
 extern const PRB_FIELD_DESC prb_fields_dcl_engines[];
 
@@ -28,7 +28,7 @@ extern const PRB_FIELD_DESC prb_fields_dcl_engines[];
 #define DCL_ENGINES_ENG_MC (&prb_fields_dcl_engines[1])
 
 // 'Engines' field lengths
-#define DCL_ENGINES_ENG_GPU_LEN 59
+#define DCL_ENGINES_ENG_GPU_LEN 65
 #define DCL_ENGINES_ENG_MC_LEN 69
 
 extern const PRB_FIELD_DESC prb_fields_dcl_dclmsg[];
@@ -49,7 +49,7 @@ extern const PRB_FIELD_DESC prb_fields_dcl_dclmsg[];
 #define DCL_DCLMSG_JOURNAL_BADREAD_LEN 70
 #define DCL_DCLMSG_JOURNAL_BUGCHECK_LEN 69
 #define DCL_DCLMSG_RCCOUNTER_LEN 64
-#define DCL_DCLMSG_ENGINE_LEN 133
+#define DCL_DCLMSG_ENGINE_LEN 139
 
 extern const PRB_FIELD_DESC prb_fields_dcl_errorblock[];
 
@@ -57,7 +57,7 @@ extern const PRB_FIELD_DESC prb_fields_dcl_errorblock[];
 #define DCL_ERRORBLOCK_DATA (&prb_fields_dcl_errorblock[0])
 
 // 'ErrorBlock' field lengths
-#define DCL_ERRORBLOCK_DATA_LEN 570
+#define DCL_ERRORBLOCK_DATA_LEN 576
 
 extern const PRB_SERVICE_DESC prb_services_dcl[];
 

--- a/src/nvidia/generated/g_engines_pb.c
+++ b/src/nvidia/generated/g_engines_pb.c
@@ -194,6 +194,18 @@ const PRB_FIELD_DESC prb_fields_nvdebug_eng_gpu[] = {
         PRB_MAYBE_FIELD_NAME("regs")
         PRB_MAYBE_FIELD_DEFAULT(0)
     },
+    {
+        39,
+        {
+            PRB_OPTIONAL,
+            PRB_UINT32,
+            0,
+        },
+        0,
+        0,
+        PRB_MAYBE_FIELD_NAME("rusd_mask")
+        PRB_MAYBE_FIELD_DEFAULT(0)
+    },
 };
 
 // 'Nvd' field defaults
@@ -210,6 +222,36 @@ const PRB_FIELD_DESC prb_fields_nvdebug_eng_nvd[] = {
         REGS_REGSANDMEM,
         0,
         PRB_MAYBE_FIELD_NAME("regs")
+        PRB_MAYBE_FIELD_DEFAULT(0)
+    },
+};
+
+// 'KGsp' field defaults
+
+// 'KGsp' field descriptors
+const PRB_FIELD_DESC prb_fields_nvdebug_eng_kgsp[] = {
+    {
+        1,
+        {
+            PRB_REPEATED,
+            PRB_MESSAGE,
+            0,
+        },
+        NVDEBUG_ENG_KGSP_RPCINFO,
+        0,
+        PRB_MAYBE_FIELD_NAME("rpc_history")
+        PRB_MAYBE_FIELD_DEFAULT(0)
+    },
+    {
+        2,
+        {
+            PRB_REPEATED,
+            PRB_MESSAGE,
+            0,
+        },
+        NVDEBUG_ENG_KGSP_RPCINFO,
+        0,
+        PRB_MAYBE_FIELD_NAME("event_history")
         PRB_MAYBE_FIELD_DEFAULT(0)
     },
 };
@@ -262,6 +304,72 @@ const PRB_FIELD_DESC prb_fields_nvdebug_eng_mc_pcibarinfo[] = {
     },
 };
 
+// 'RpcInfo' field defaults
+
+// 'RpcInfo' field descriptors
+const PRB_FIELD_DESC prb_fields_nvdebug_eng_kgsp_rpcinfo[] = {
+    {
+        1,
+        {
+            PRB_REQUIRED,
+            PRB_UINT32,
+            0,
+        },
+        0,
+        0,
+        PRB_MAYBE_FIELD_NAME("function")
+        PRB_MAYBE_FIELD_DEFAULT(0)
+    },
+    {
+        2,
+        {
+            PRB_REQUIRED,
+            PRB_UINT64,
+            0,
+        },
+        0,
+        0,
+        PRB_MAYBE_FIELD_NAME("ts_start")
+        PRB_MAYBE_FIELD_DEFAULT(0)
+    },
+    {
+        3,
+        {
+            PRB_REQUIRED,
+            PRB_UINT64,
+            0,
+        },
+        0,
+        0,
+        PRB_MAYBE_FIELD_NAME("ts_end")
+        PRB_MAYBE_FIELD_DEFAULT(0)
+    },
+    {
+        4,
+        {
+            PRB_OPTIONAL,
+            PRB_UINT32,
+            0,
+        },
+        0,
+        0,
+        PRB_MAYBE_FIELD_NAME("data0")
+        PRB_MAYBE_FIELD_DEFAULT(0)
+    },
+    {
+        5,
+        {
+            PRB_OPTIONAL,
+            PRB_UINT32,
+            0,
+        },
+        0,
+        0,
+        PRB_MAYBE_FIELD_NAME("data1")
+        PRB_MAYBE_FIELD_DEFAULT(0)
+    },
+};
+
 // Message descriptors
 const PRB_MSG_DESC prb_messages_nvdebug_eng[] = {
     {
@@ -270,7 +378,7 @@ const PRB_MSG_DESC prb_messages_nvdebug_eng[] = {
         PRB_MAYBE_MESSAGE_NAME("NvDebug.Eng.Mc")
     },
     {
-        12,
+        13,
         prb_fields_nvdebug_eng_gpu,
         PRB_MAYBE_MESSAGE_NAME("NvDebug.Eng.Gpu")
     },
@@ -278,6 +386,11 @@ const PRB_MSG_DESC prb_messages_nvdebug_eng[] = {
         1,
         prb_fields_nvdebug_eng_nvd,
         PRB_MAYBE_MESSAGE_NAME("NvDebug.Eng.Nvd")
+    },
+    {
+        2,
+        prb_fields_nvdebug_eng_kgsp,
+        PRB_MAYBE_MESSAGE_NAME("NvDebug.Eng.KGsp")
     },
     {
         1,
@@ -288,6 +401,11 @@ const PRB_MSG_DESC prb_messages_nvdebug_eng[] = {
         2,
         prb_fields_nvdebug_eng_mc_pcibarinfo,
         PRB_MAYBE_MESSAGE_NAME("NvDebug.Eng.Mc.PciBarInfo")
+    },
+    {
+        5,
+        prb_fields_nvdebug_eng_kgsp_rpcinfo,
+        PRB_MAYBE_MESSAGE_NAME("NvDebug.Eng.KGsp.RpcInfo")
     },
 };
 

--- a/src/nvidia/generated/g_engines_pb.h
+++ b/src/nvidia/generated/g_engines_pb.h
@@ -11,16 +11,20 @@ extern const PRB_MSG_DESC prb_messages_nvdebug_eng[];
 #define NVDEBUG_ENG_MC (&prb_messages_nvdebug_eng[0])
 #define NVDEBUG_ENG_GPU (&prb_messages_nvdebug_eng[1])
 #define NVDEBUG_ENG_NVD (&prb_messages_nvdebug_eng[2])
-#define NVDEBUG_ENG_MC_RMDATA (&prb_messages_nvdebug_eng[3])
-#define NVDEBUG_ENG_MC_PCIBARINFO (&prb_messages_nvdebug_eng[4])
+#define NVDEBUG_ENG_KGSP (&prb_messages_nvdebug_eng[3])
+#define NVDEBUG_ENG_MC_RMDATA (&prb_messages_nvdebug_eng[4])
+#define NVDEBUG_ENG_MC_PCIBARINFO (&prb_messages_nvdebug_eng[5])
+#define NVDEBUG_ENG_KGSP_RPCINFO (&prb_messages_nvdebug_eng[6])
 
 // Message maximum lengths
 // Does not include repeated fields, strings and byte arrays.
 #define NVDEBUG_ENG_MC_LEN 66
-#define NVDEBUG_ENG_GPU_LEN 56
+#define NVDEBUG_ENG_GPU_LEN 62
 #define NVDEBUG_ENG_NVD_LEN 30
+#define NVDEBUG_ENG_KGSP_LEN 88
 #define NVDEBUG_ENG_MC_RMDATA_LEN 6
 #define NVDEBUG_ENG_MC_PCIBARINFO_LEN 22
+#define NVDEBUG_ENG_KGSP_RPCINFO_LEN 40
 
 extern const PRB_FIELD_DESC prb_fields_nvdebug_eng_mc[];
 
@@ -49,6 +53,7 @@ extern const PRB_FIELD_DESC prb_fields_nvdebug_eng_gpu[];
 #define NVDEBUG_ENG_GPU_IS_LOST (&prb_fields_nvdebug_eng_gpu[9])
 #define NVDEBUG_ENG_GPU_IS_ACCESSIBLE (&prb_fields_nvdebug_eng_gpu[10])
 #define NVDEBUG_ENG_GPU_REGS (&prb_fields_nvdebug_eng_gpu[11])
+#define NVDEBUG_ENG_GPU_RUSD_MASK (&prb_fields_nvdebug_eng_gpu[12])
 
 // 'Gpu' field lengths
 #define NVDEBUG_ENG_GPU_GPU_ID_LEN 5
@@ -63,6 +68,7 @@ extern const PRB_FIELD_DESC prb_fields_nvdebug_eng_gpu[];
 #define NVDEBUG_ENG_GPU_IS_LOST_LEN 1
 #define NVDEBUG_ENG_GPU_IS_ACCESSIBLE_LEN 1
 #define NVDEBUG_ENG_GPU_REGS_LEN 29
+#define NVDEBUG_ENG_GPU_RUSD_MASK_LEN 5
 
 extern const PRB_FIELD_DESC prb_fields_nvdebug_eng_nvd[];
 
@@ -71,6 +77,16 @@ extern const PRB_FIELD_DESC prb_fields_nvdebug_eng_nvd[];
 
 // 'Nvd' field lengths
 #define NVDEBUG_ENG_NVD_REGS_LEN 29
+
+extern const PRB_FIELD_DESC prb_fields_nvdebug_eng_kgsp[];
+
+// 'KGsp' field descriptor pointers
+#define NVDEBUG_ENG_KGSP_RPC_HISTORY (&prb_fields_nvdebug_eng_kgsp[0])
+#define NVDEBUG_ENG_KGSP_EVENT_HISTORY (&prb_fields_nvdebug_eng_kgsp[1])
+
+// 'KGsp' field lengths
+#define NVDEBUG_ENG_KGSP_RPC_HISTORY_LEN 43
+#define NVDEBUG_ENG_KGSP_EVENT_HISTORY_LEN 43
 
 extern const PRB_FIELD_DESC prb_fields_nvdebug_eng_mc_rmdata[];
 
@@ -89,6 +105,22 @@ extern const PRB_FIELD_DESC prb_fields_nvdebug_eng_mc_pcibarinfo[];
 // 'PciBarInfo' field lengths
 #define NVDEBUG_ENG_MC_PCIBARINFO_OFFSET_LEN 10
 #define NVDEBUG_ENG_MC_PCIBARINFO_LENGTH_LEN 10
+
+extern const PRB_FIELD_DESC prb_fields_nvdebug_eng_kgsp_rpcinfo[];
+
+// 'RpcInfo' field descriptor pointers
+#define NVDEBUG_ENG_KGSP_RPCINFO_FUNCTION (&prb_fields_nvdebug_eng_kgsp_rpcinfo[0])
+#define NVDEBUG_ENG_KGSP_RPCINFO_TS_START (&prb_fields_nvdebug_eng_kgsp_rpcinfo[1])
+#define NVDEBUG_ENG_KGSP_RPCINFO_TS_END (&prb_fields_nvdebug_eng_kgsp_rpcinfo[2])
+#define NVDEBUG_ENG_KGSP_RPCINFO_DATA0 (&prb_fields_nvdebug_eng_kgsp_rpcinfo[3])
+#define NVDEBUG_ENG_KGSP_RPCINFO_DATA1 (&prb_fields_nvdebug_eng_kgsp_rpcinfo[4])
+
+// 'RpcInfo' field lengths
+#define NVDEBUG_ENG_KGSP_RPCINFO_FUNCTION_LEN 5
+#define NVDEBUG_ENG_KGSP_RPCINFO_TS_START_LEN 10
+#define NVDEBUG_ENG_KGSP_RPCINFO_TS_END_LEN 10
+#define NVDEBUG_ENG_KGSP_RPCINFO_DATA0_LEN 5
+#define NVDEBUG_ENG_KGSP_RPCINFO_DATA1_LEN 5
 
 extern const PRB_SERVICE_DESC prb_services_nvdebug_eng[];
 

--- a/src/nvidia/generated/g_kernel_gsp_nvoc.c
+++ b/src/nvidia/generated/g_kernel_gsp_nvoc.c
@@ -102,11 +102,16 @@ const struct NVOC_CLASS_DEF __nvoc_class_def_KernelGsp =
     /*pExportInfo=*/        &__nvoc_export_info_KernelGsp
 };
 
-// 5 down-thunk(s) defined to bridge methods in KernelGsp from superclasses
+// 6 down-thunk(s) defined to bridge methods in KernelGsp from superclasses
 
 // kgspConstructEngine: virtual override (engstate) base (engstate)
 static NV_STATUS __nvoc_down_thunk_KernelGsp_engstateConstructEngine(struct OBJGPU *pGpu, struct OBJENGSTATE *pKernelGsp, ENGDESCRIPTOR arg3) {
     return kgspConstructEngine(pGpu, (struct KernelGsp *)(((unsigned char *) pKernelGsp) - __nvoc_rtti_KernelGsp_OBJENGSTATE.offset), arg3);
+}
+
+// kgspStateInitLocked: virtual override (engstate) base (engstate)
+static NV_STATUS __nvoc_down_thunk_KernelGsp_engstateStateInitLocked(struct OBJGPU *pGpu, struct OBJENGSTATE *pKernelGsp) {
+    return kgspStateInitLocked(pGpu, (struct KernelGsp *)(((unsigned char *) pKernelGsp) - __nvoc_rtti_KernelGsp_OBJENGSTATE.offset));
 }
 
 // kgspRegisterIntrService: virtual override (intrserv) base (intrserv)
@@ -130,7 +135,7 @@ static void __nvoc_down_thunk_KernelGsp_kcrashcatEngineReadEmem(struct KernelCra
 }
 
 
-// 29 up-thunk(s) defined to bridge methods in KernelGsp to superclasses
+// 28 up-thunk(s) defined to bridge methods in KernelGsp to superclasses
 
 // kgspInitMissing: virtual inherited (engstate) base (engstate)
 static void __nvoc_up_thunk_OBJENGSTATE_kgspInitMissing(POBJGPU pGpu, struct KernelGsp *pEngstate) {
@@ -145,11 +150,6 @@ static NV_STATUS __nvoc_up_thunk_OBJENGSTATE_kgspStatePreInitLocked(POBJGPU pGpu
 // kgspStatePreInitUnlocked: virtual inherited (engstate) base (engstate)
 static NV_STATUS __nvoc_up_thunk_OBJENGSTATE_kgspStatePreInitUnlocked(POBJGPU pGpu, struct KernelGsp *pEngstate) {
     return engstateStatePreInitUnlocked(pGpu, (struct OBJENGSTATE *)(((unsigned char *) pEngstate) + __nvoc_rtti_KernelGsp_OBJENGSTATE.offset));
-}
-
-// kgspStateInitLocked: virtual inherited (engstate) base (engstate)
-static NV_STATUS __nvoc_up_thunk_OBJENGSTATE_kgspStateInitLocked(POBJGPU pGpu, struct KernelGsp *pEngstate) {
-    return engstateStateInitLocked(pGpu, (struct OBJENGSTATE *)(((unsigned char *) pEngstate) + __nvoc_rtti_KernelGsp_OBJENGSTATE.offset));
 }
 
 // kgspStateInitUnlocked: virtual inherited (engstate) base (engstate)
@@ -406,6 +406,10 @@ static void __nvoc_init_funcTable_KernelGsp_1(KernelGsp *pThis, RmHalspecOwner *
     // kgspConstructEngine -- virtual override (engstate) base (engstate)
     pThis->__kgspConstructEngine__ = &kgspConstructEngine_IMPL;
     pThis->__nvoc_base_OBJENGSTATE.__engstateConstructEngine__ = &__nvoc_down_thunk_KernelGsp_engstateConstructEngine;
+
+    // kgspStateInitLocked -- virtual override (engstate) base (engstate)
+    pThis->__kgspStateInitLocked__ = &kgspStateInitLocked_IMPL;
+    pThis->__nvoc_base_OBJENGSTATE.__engstateStateInitLocked__ = &__nvoc_down_thunk_KernelGsp_engstateStateInitLocked;
 
     // kgspRegisterIntrService -- virtual override (intrserv) base (intrserv)
     pThis->__kgspRegisterIntrService__ = &kgspRegisterIntrService_IMPL;
@@ -1272,9 +1276,6 @@ static void __nvoc_init_funcTable_KernelGsp_1(KernelGsp *pThis, RmHalspecOwner *
     // kgspStatePreInitUnlocked -- virtual inherited (engstate) base (engstate)
     pThis->__kgspStatePreInitUnlocked__ = &__nvoc_up_thunk_OBJENGSTATE_kgspStatePreInitUnlocked;
 
-    // kgspStateInitLocked -- virtual inherited (engstate) base (engstate)
-    pThis->__kgspStateInitLocked__ = &__nvoc_up_thunk_OBJENGSTATE_kgspStateInitLocked;
-
     // kgspStateInitUnlocked -- virtual inherited (engstate) base (engstate)
     pThis->__kgspStateInitUnlocked__ = &__nvoc_up_thunk_OBJENGSTATE_kgspStateInitUnlocked;
 
@@ -1349,7 +1350,7 @@ static void __nvoc_init_funcTable_KernelGsp_1(KernelGsp *pThis, RmHalspecOwner *
 
     // kgspGetWFL0Offset -- virtual halified (singleton optimized) inherited (kcrashcatEngine) base (kflcn)
     pThis->__kgspGetWFL0Offset__ = &__nvoc_up_thunk_KernelCrashCatEngine_kgspGetWFL0Offset;
-} // End __nvoc_init_funcTable_KernelGsp_1 with approximately 195 basic block(s).
+} // End __nvoc_init_funcTable_KernelGsp_1 with approximately 196 basic block(s).
 
 
 // Initialize vtable(s) for 82 virtual method(s).

--- a/src/nvidia/generated/g_kernel_gsp_nvoc.h
+++ b/src/nvidia/generated/g_kernel_gsp_nvoc.h
@@ -332,6 +332,7 @@ struct KernelGsp {
 
     // Vtable with 82 per-object function pointers
     NV_STATUS (*__kgspConstructEngine__)(struct OBJGPU *, struct KernelGsp * /*this*/, ENGDESCRIPTOR);  // virtual override (engstate) base (engstate)
+    NV_STATUS (*__kgspStateInitLocked__)(struct OBJGPU *, struct KernelGsp * /*this*/);  // virtual override (engstate) base (engstate)
     void (*__kgspRegisterIntrService__)(struct OBJGPU *, struct KernelGsp * /*this*/, IntrServiceRecord *);  // virtual override (intrserv) base (intrserv)
     NvU32 (*__kgspServiceInterrupt__)(struct OBJGPU *, struct KernelGsp * /*this*/, IntrServiceServiceInterruptArguments *);  // virtual override (intrserv) base (intrserv)
     void (*__kgspConfigureFalcon__)(struct OBJGPU *, struct KernelGsp * /*this*/);  // halified (3 hals) body
@@ -387,7 +388,6 @@ struct KernelGsp {
     void (*__kgspInitMissing__)(POBJGPU, struct KernelGsp * /*this*/);  // virtual inherited (engstate) base (engstate)
     NV_STATUS (*__kgspStatePreInitLocked__)(POBJGPU, struct KernelGsp * /*this*/);  // virtual inherited (engstate) base (engstate)
     NV_STATUS (*__kgspStatePreInitUnlocked__)(POBJGPU, struct KernelGsp * /*this*/);  // virtual inherited (engstate) base (engstate)
-    NV_STATUS (*__kgspStateInitLocked__)(POBJGPU, struct KernelGsp * /*this*/);  // virtual inherited (engstate) base (engstate)
     NV_STATUS (*__kgspStateInitUnlocked__)(POBJGPU, struct KernelGsp * /*this*/);  // virtual inherited (engstate) base (engstate)
     NV_STATUS (*__kgspStatePreLoad__)(POBJGPU, struct KernelGsp * /*this*/, NvU32);  // virtual inherited (engstate) base (engstate)
     NV_STATUS (*__kgspStateLoad__)(POBJGPU, struct KernelGsp * /*this*/, NvU32);  // virtual inherited (engstate) base (engstate)
@@ -512,6 +512,8 @@ NV_STATUS __nvoc_objCreate_KernelGsp(KernelGsp**, Dynamic*, NvU32);
 // Wrapper macros
 #define kgspConstructEngine_FNPTR(pKernelGsp) pKernelGsp->__kgspConstructEngine__
 #define kgspConstructEngine(pGpu, pKernelGsp, arg3) kgspConstructEngine_DISPATCH(pGpu, pKernelGsp, arg3)
+#define kgspStateInitLocked_FNPTR(pKernelGsp) pKernelGsp->__kgspStateInitLocked__
+#define kgspStateInitLocked(pGpu, pKernelGsp) kgspStateInitLocked_DISPATCH(pGpu, pKernelGsp)
 #define kgspRegisterIntrService_FNPTR(pKernelGsp) pKernelGsp->__kgspRegisterIntrService__
 #define kgspRegisterIntrService(pGpu, pKernelGsp, pRecords) kgspRegisterIntrService_DISPATCH(pGpu, pKernelGsp, pRecords)
 #define kgspServiceInterrupt_FNPTR(pKernelGsp) pKernelGsp->__kgspServiceInterrupt__
@@ -672,8 +674,6 @@ NV_STATUS __nvoc_objCreate_KernelGsp(KernelGsp**, Dynamic*, NvU32);
 #define kgspStatePreInitLocked(pGpu, pEngstate) kgspStatePreInitLocked_DISPATCH(pGpu, pEngstate)
 #define kgspStatePreInitUnlocked_FNPTR(pEngstate) pEngstate->__nvoc_base_OBJENGSTATE.__engstateStatePreInitUnlocked__
 #define kgspStatePreInitUnlocked(pGpu, pEngstate) kgspStatePreInitUnlocked_DISPATCH(pGpu, pEngstate)
-#define kgspStateInitLocked_FNPTR(pEngstate) pEngstate->__nvoc_base_OBJENGSTATE.__engstateStateInitLocked__
-#define kgspStateInitLocked(pGpu, pEngstate) kgspStateInitLocked_DISPATCH(pGpu, pEngstate)
 #define kgspStateInitUnlocked_FNPTR(pEngstate) pEngstate->__nvoc_base_OBJENGSTATE.__engstateStateInitUnlocked__
 #define kgspStateInitUnlocked(pGpu, pEngstate) kgspStateInitUnlocked_DISPATCH(pGpu, pEngstate)
 #define kgspStatePreLoad_FNPTR(pEngstate) pEngstate->__nvoc_base_OBJENGSTATE.__engstateStatePreLoad__
@@ -734,6 +734,10 @@ NV_STATUS __nvoc_objCreate_KernelGsp(KernelGsp**, Dynamic*, NvU32);
 // Dispatch functions
 static inline NV_STATUS kgspConstructEngine_DISPATCH(struct OBJGPU *pGpu, struct KernelGsp *pKernelGsp, ENGDESCRIPTOR arg3) {
     return pKernelGsp->__kgspConstructEngine__(pGpu, pKernelGsp, arg3);
+}
+
+static inline NV_STATUS kgspStateInitLocked_DISPATCH(struct OBJGPU *pGpu, struct KernelGsp *pKernelGsp) {
+    return pKernelGsp->__kgspStateInitLocked__(pGpu, pKernelGsp);
 }
 
 static inline void kgspRegisterIntrService_DISPATCH(struct OBJGPU *pGpu, struct KernelGsp *pKernelGsp, IntrServiceRecord pRecords[175]) {
@@ -956,10 +960,6 @@ static inline NV_STATUS kgspStatePreInitUnlocked_DISPATCH(POBJGPU pGpu, struct K
     return pEngstate->__kgspStatePreInitUnlocked__(pGpu, pEngstate);
 }
 
-static inline NV_STATUS kgspStateInitLocked_DISPATCH(POBJGPU pGpu, struct KernelGsp *pEngstate) {
-    return pEngstate->__kgspStateInitLocked__(pGpu, pEngstate);
-}
-
 static inline NV_STATUS kgspStateInitUnlocked_DISPATCH(POBJGPU pGpu, struct KernelGsp *pEngstate) {
     return pEngstate->__kgspStateInitUnlocked__(pGpu, pEngstate);
 }
@@ -1061,6 +1061,8 @@ static inline NvU32 kgspGetWFL0Offset_DISPATCH(struct KernelGsp *arg_this) {
 }
 
 NV_STATUS kgspConstructEngine_IMPL(struct OBJGPU *pGpu, struct KernelGsp *pKernelGsp, ENGDESCRIPTOR arg3);
+
+NV_STATUS kgspStateInitLocked_IMPL(struct OBJGPU *pGpu, struct KernelGsp *pKernelGsp);
 
 void kgspRegisterIntrService_IMPL(struct OBJGPU *pGpu, struct KernelGsp *pKernelGsp, IntrServiceRecord pRecords[175]);
 

--- a/src/nvidia/generated/g_nvdebug_pb.c
+++ b/src/nvidia/generated/g_nvdebug_pb.c
@@ -194,6 +194,18 @@ const PRB_FIELD_DESC prb_fields_nvdebug_systeminfo[] = {
         PRB_MAYBE_FIELD_NAME("bugcheck_count")
         PRB_MAYBE_FIELD_DEFAULT(0)
     },
+    {
+        13,
+        {
+            PRB_OPTIONAL,
+            PRB_MESSAGE,
+            0,
+        },
+        NVDEBUG_SYSTEMINFO_RESOURCESERVER,
+        0,
+        PRB_MAYBE_FIELD_NAME("resserv_info")
+        PRB_MAYBE_FIELD_DEFAULT(0)
+    },
 };
 
 // 'GpuInfo' field defaults
@@ -234,6 +246,18 @@ const PRB_FIELD_DESC prb_fields_nvdebug_gpuinfo[] = {
         NVDEBUG_ENG_NVD,
         0,
         PRB_MAYBE_FIELD_NAME("eng_nvd")
+        PRB_MAYBE_FIELD_DEFAULT(0)
+    },
+    {
+        24,
+        {
+            PRB_REPEATED,
+            PRB_MESSAGE,
+            0,
+        },
+        NVDEBUG_ENG_KGSP,
+        0,
+        PRB_MAYBE_FIELD_NAME("eng_kgsp")
         PRB_MAYBE_FIELD_DEFAULT(0)
     },
 };
@@ -838,15 +862,189 @@ const PRB_FIELD_DESC prb_fields_nvdebug_systeminfo_timeinfo[] = {
     },
 };
 
+// 'ResourceServer' field defaults
+
+// 'ResourceServer' field descriptors
+const PRB_FIELD_DESC prb_fields_nvdebug_systeminfo_resourceserver[] = {
+    {
+        1,
+        {
+            PRB_REQUIRED,
+            PRB_UINT32,
+            0,
+        },
+        0,
+        0,
+        PRB_MAYBE_FIELD_NAME("num_clients")
+        PRB_MAYBE_FIELD_DEFAULT(0)
+    },
+    {
+        2,
+        {
+            PRB_REQUIRED,
+            PRB_UINT64,
+            0,
+        },
+        0,
+        0,
+        PRB_MAYBE_FIELD_NAME("num_resources")
+        PRB_MAYBE_FIELD_DEFAULT(0)
+    },
+    {
+        3,
+        {
+            PRB_REPEATED,
+            PRB_MESSAGE,
+            0,
+        },
+        NVDEBUG_SYSTEMINFO_RESOURCESERVER_CLIENTINFO,
+        0,
+        PRB_MAYBE_FIELD_NAME("client_info")
+        PRB_MAYBE_FIELD_DEFAULT(0)
+    },
+};
+
+// 'ClientInfo' field defaults
+
+// 'ClientInfo' field descriptors
+const PRB_FIELD_DESC prb_fields_nvdebug_systeminfo_resourceserver_clientinfo[] = {
+    {
+        1,
+        {
+            PRB_REQUIRED,
+            PRB_UINT32,
+            0,
+        },
+        0,
+        0,
+        PRB_MAYBE_FIELD_NAME("client_handle")
+        PRB_MAYBE_FIELD_DEFAULT(0)
+    },
+    {
+        2,
+        {
+            PRB_REQUIRED,
+            PRB_UINT32,
+            0,
+        },
+        0,
+        0,
+        PRB_MAYBE_FIELD_NAME("process_id")
+        PRB_MAYBE_FIELD_DEFAULT(0)
+    },
+    {
+        3,
+        {
+            PRB_REQUIRED,
+            PRB_STRING,
+            0,
+        },
+        0,
+        0,
+        PRB_MAYBE_FIELD_NAME("process_name")
+        PRB_MAYBE_FIELD_DEFAULT(0)
+    },
+    {
+        4,
+        {
+            PRB_REQUIRED,
+            PRB_UINT32,
+            0,
+        },
+        0,
+        0,
+        PRB_MAYBE_FIELD_NAME("flags")
+        PRB_MAYBE_FIELD_DEFAULT(0)
+    },
+    {
+        5,
+        {
+            PRB_REQUIRED,
+            PRB_UINT32,
+            0,
+        },
+        0,
+        0,
+        PRB_MAYBE_FIELD_NAME("priv_level")
+        PRB_MAYBE_FIELD_DEFAULT(0)
+    },
+    {
+        6,
+        {
+            PRB_REPEATED,
+            PRB_MESSAGE,
+            0,
+        },
+        NVDEBUG_SYSTEMINFO_RESOURCESERVER_CLIENTINFO_CLIENTALLOCATION,
+        0,
+        PRB_MAYBE_FIELD_NAME("allocations")
+        PRB_MAYBE_FIELD_DEFAULT(0)
+    },
+};
+
+// 'ClientAllocation' field defaults
+
+// 'ClientAllocation' field descriptors
+const PRB_FIELD_DESC prb_fields_nvdebug_systeminfo_resourceserver_clientinfo_clientallocation[] = {
+    {
+        1,
+        {
+            PRB_REQUIRED,
+            PRB_UINT32,
+            0,
+        },
+        0,
+        0,
+        PRB_MAYBE_FIELD_NAME("object_handle")
+        PRB_MAYBE_FIELD_DEFAULT(0)
+    },
+    {
+        2,
+        {
+            PRB_REQUIRED,
+            PRB_UINT32,
+            0,
+        },
+        0,
+        0,
+        PRB_MAYBE_FIELD_NAME("object_class_id")
+        PRB_MAYBE_FIELD_DEFAULT(0)
+    },
+    {
+        3,
+        {
+            PRB_REQUIRED,
+            PRB_UINT32,
+            0,
+        },
+        0,
+        0,
+        PRB_MAYBE_FIELD_NAME("parent_handle")
+        PRB_MAYBE_FIELD_DEFAULT(0)
+    },
+    {
+        4,
+        {
+            PRB_OPTIONAL,
+            PRB_UINT32,
+            0,
+        },
+        0,
+        0,
+        PRB_MAYBE_FIELD_NAME("gpu_instance")
+        PRB_MAYBE_FIELD_DEFAULT(0)
+    },
+};
+
 // Message descriptors
 const PRB_MSG_DESC prb_messages_nvdebug[] = {
     {
-        12,
+        13,
         prb_fields_nvdebug_systeminfo,
         PRB_MAYBE_MESSAGE_NAME("NvDebug.SystemInfo")
     },
     {
-        3,
+        4,
         prb_fields_nvdebug_gpuinfo,
         PRB_MAYBE_MESSAGE_NAME("NvDebug.GpuInfo")
     },
@@ -899,6 +1097,21 @@ const PRB_MSG_DESC prb_messages_nvdebug[] = {
         5,
         prb_fields_nvdebug_systeminfo_timeinfo,
         PRB_MAYBE_MESSAGE_NAME("NvDebug.SystemInfo.TimeInfo")
+    },
+    {
+        3,
+        prb_fields_nvdebug_systeminfo_resourceserver,
+        PRB_MAYBE_MESSAGE_NAME("NvDebug.SystemInfo.ResourceServer")
+    },
+    {
+        6,
+        prb_fields_nvdebug_systeminfo_resourceserver_clientinfo,
+        PRB_MAYBE_MESSAGE_NAME("NvDebug.SystemInfo.ResourceServer.ClientInfo")
+    },
+    {
+        4,
+        prb_fields_nvdebug_systeminfo_resourceserver_clientinfo_clientallocation,
+        PRB_MAYBE_MESSAGE_NAME("NvDebug.SystemInfo.ResourceServer.ClientInfo.ClientAllocation")
     },
 };
 

--- a/src/nvidia/generated/g_nvdebug_pb.h
+++ b/src/nvidia/generated/g_nvdebug_pb.h
@@ -35,12 +35,15 @@ extern const PRB_MSG_DESC prb_messages_nvdebug[];
 #define NVDEBUG_SYSTEMINFO_CONFIG (&prb_messages_nvdebug[9])
 #define NVDEBUG_SYSTEMINFO_ERRORSTATE (&prb_messages_nvdebug[10])
 #define NVDEBUG_SYSTEMINFO_TIMEINFO (&prb_messages_nvdebug[11])
+#define NVDEBUG_SYSTEMINFO_RESOURCESERVER (&prb_messages_nvdebug[12])
+#define NVDEBUG_SYSTEMINFO_RESOURCESERVER_CLIENTINFO (&prb_messages_nvdebug[13])
+#define NVDEBUG_SYSTEMINFO_RESOURCESERVER_CLIENTINFO_CLIENTALLOCATION (&prb_messages_nvdebug[14])
 
 // Message maximum lengths
 // Does not include repeated fields, strings and byte arrays.
-#define NVDEBUG_SYSTEMINFO_LEN 275
-#define NVDEBUG_GPUINFO_LEN 164
-#define NVDEBUG_NVDUMP_LEN 1308
+#define NVDEBUG_SYSTEMINFO_LEN 354
+#define NVDEBUG_GPUINFO_LEN 262
+#define NVDEBUG_NVDUMP_LEN 1570
 #define NVDEBUG_SYSTEMINFO_NORTHBRIDGEINFO_LEN 12
 #define NVDEBUG_SYSTEMINFO_SOCINFO_LEN 12
 #define NVDEBUG_SYSTEMINFO_CPUINFO_LEN 24
@@ -50,6 +53,9 @@ extern const PRB_MSG_DESC prb_messages_nvdebug[];
 #define NVDEBUG_SYSTEMINFO_CONFIG_LEN 12
 #define NVDEBUG_SYSTEMINFO_ERRORSTATE_LEN 14
 #define NVDEBUG_SYSTEMINFO_TIMEINFO_LEN 45
+#define NVDEBUG_SYSTEMINFO_RESOURCESERVER_LEN 75
+#define NVDEBUG_SYSTEMINFO_RESOURCESERVER_CLIENTINFO_LEN 54
+#define NVDEBUG_SYSTEMINFO_RESOURCESERVER_CLIENTINFO_CLIENTALLOCATION_LEN 24
 
 extern const PRB_FIELD_DESC prb_fields_nvdebug_systeminfo[];
 
@@ -66,6 +72,7 @@ extern const PRB_FIELD_DESC prb_fields_nvdebug_systeminfo[];
 #define NVDEBUG_SYSTEMINFO_TIME_SINCE_BOOT (&prb_fields_nvdebug_systeminfo[9])
 #define NVDEBUG_SYSTEMINFO_TIME_INFO (&prb_fields_nvdebug_systeminfo[10])
 #define NVDEBUG_SYSTEMINFO_BUGCHECK_COUNT (&prb_fields_nvdebug_systeminfo[11])
+#define NVDEBUG_SYSTEMINFO_RESSERV_INFO (&prb_fields_nvdebug_systeminfo[12])
 
 // 'SystemInfo' field lengths
 #define NVDEBUG_SYSTEMINFO_TIMESTAMP_LEN 10
@@ -80,6 +87,7 @@ extern const PRB_FIELD_DESC prb_fields_nvdebug_systeminfo[];
 #define NVDEBUG_SYSTEMINFO_TIME_SINCE_BOOT_LEN 5
 #define NVDEBUG_SYSTEMINFO_TIME_INFO_LEN 48
 #define NVDEBUG_SYSTEMINFO_BUGCHECK_COUNT_LEN 5
+#define NVDEBUG_SYSTEMINFO_RESSERV_INFO_LEN 78
 
 extern const PRB_FIELD_DESC prb_fields_nvdebug_gpuinfo[];
 
@@ -87,11 +95,13 @@ extern const PRB_FIELD_DESC prb_fields_nvdebug_gpuinfo[];
 #define NVDEBUG_GPUINFO_ENG_GPU (&prb_fields_nvdebug_gpuinfo[0])
 #define NVDEBUG_GPUINFO_ENG_MC (&prb_fields_nvdebug_gpuinfo[1])
 #define NVDEBUG_GPUINFO_ENG_NVD (&prb_fields_nvdebug_gpuinfo[2])
+#define NVDEBUG_GPUINFO_ENG_KGSP (&prb_fields_nvdebug_gpuinfo[3])
 
 // 'GpuInfo' field lengths
-#define NVDEBUG_GPUINFO_ENG_GPU_LEN 59
+#define NVDEBUG_GPUINFO_ENG_GPU_LEN 65
 #define NVDEBUG_GPUINFO_ENG_MC_LEN 69
 #define NVDEBUG_GPUINFO_ENG_NVD_LEN 33
+#define NVDEBUG_GPUINFO_ENG_KGSP_LEN 91
 
 extern const PRB_FIELD_DESC prb_fields_nvdebug_nvdump[];
 
@@ -103,11 +113,11 @@ extern const PRB_FIELD_DESC prb_fields_nvdebug_nvdump[];
 #define NVDEBUG_NVDUMP_SYSTEM_INFO_GSPRM (&prb_fields_nvdebug_nvdump[4])
 
 // 'NvDump' field lengths
-#define NVDEBUG_NVDUMP_SYSTEM_INFO_LEN 278
-#define NVDEBUG_NVDUMP_DCL_MSG_LEN 570
-#define NVDEBUG_NVDUMP_GPU_INFO_LEN 167
+#define NVDEBUG_NVDUMP_SYSTEM_INFO_LEN 357
+#define NVDEBUG_NVDUMP_DCL_MSG_LEN 576
+#define NVDEBUG_NVDUMP_GPU_INFO_LEN 265
 #define NVDEBUG_NVDUMP_EXCEPTION_ADDRESS_LEN 10
-#define NVDEBUG_NVDUMP_SYSTEM_INFO_GSPRM_LEN 278
+#define NVDEBUG_NVDUMP_SYSTEM_INFO_GSPRM_LEN 357
 
 extern const PRB_FIELD_DESC prb_fields_nvdebug_systeminfo_northbridgeinfo[];
 
@@ -242,6 +252,50 @@ extern const PRB_FIELD_DESC prb_fields_nvdebug_systeminfo_timeinfo[];
 #define NVDEBUG_SYSTEMINFO_TIMEINFO_SYSTEM_TIME_DUMP_LEN 10
 #define NVDEBUG_SYSTEMINFO_TIMEINFO_TIME_SINCE_BOOT_US_LEN 5
 #define NVDEBUG_SYSTEMINFO_TIMEINFO_TIME_SINCE_BOOT_SEC_LEN 5
+
+extern const PRB_FIELD_DESC prb_fields_nvdebug_systeminfo_resourceserver[];
+
+// 'ResourceServer' field descriptor pointers
+#define NVDEBUG_SYSTEMINFO_RESOURCESERVER_NUM_CLIENTS (&prb_fields_nvdebug_systeminfo_resourceserver[0])
+#define NVDEBUG_SYSTEMINFO_RESOURCESERVER_NUM_RESOURCES (&prb_fields_nvdebug_systeminfo_resourceserver[1])
+#define NVDEBUG_SYSTEMINFO_RESOURCESERVER_CLIENT_INFO (&prb_fields_nvdebug_systeminfo_resourceserver[2])
+
+// 'ResourceServer' field lengths
+#define NVDEBUG_SYSTEMINFO_RESOURCESERVER_NUM_CLIENTS_LEN 5
+#define NVDEBUG_SYSTEMINFO_RESOURCESERVER_NUM_RESOURCES_LEN 10
+#define NVDEBUG_SYSTEMINFO_RESOURCESERVER_CLIENT_INFO_LEN 57
+
+extern const PRB_FIELD_DESC prb_fields_nvdebug_systeminfo_resourceserver_clientinfo[];
+
+// 'ClientInfo' field descriptor pointers
+#define NVDEBUG_SYSTEMINFO_RESOURCESERVER_CLIENTINFO_CLIENT_HANDLE (&prb_fields_nvdebug_systeminfo_resourceserver_clientinfo[0])
+#define NVDEBUG_SYSTEMINFO_RESOURCESERVER_CLIENTINFO_PROCESS_ID (&prb_fields_nvdebug_systeminfo_resourceserver_clientinfo[1])
+#define NVDEBUG_SYSTEMINFO_RESOURCESERVER_CLIENTINFO_PROCESS_NAME (&prb_fields_nvdebug_systeminfo_resourceserver_clientinfo[2])
+#define NVDEBUG_SYSTEMINFO_RESOURCESERVER_CLIENTINFO_FLAGS (&prb_fields_nvdebug_systeminfo_resourceserver_clientinfo[3])
+#define NVDEBUG_SYSTEMINFO_RESOURCESERVER_CLIENTINFO_PRIV_LEVEL (&prb_fields_nvdebug_systeminfo_resourceserver_clientinfo[4])
+#define NVDEBUG_SYSTEMINFO_RESOURCESERVER_CLIENTINFO_ALLOCATIONS (&prb_fields_nvdebug_systeminfo_resourceserver_clientinfo[5])
+
+// 'ClientInfo' field lengths
+#define NVDEBUG_SYSTEMINFO_RESOURCESERVER_CLIENTINFO_CLIENT_HANDLE_LEN 5
+#define NVDEBUG_SYSTEMINFO_RESOURCESERVER_CLIENTINFO_PROCESS_ID_LEN 5
+#define NVDEBUG_SYSTEMINFO_RESOURCESERVER_CLIENTINFO_PROCESS_NAME_LEN 1
+#define NVDEBUG_SYSTEMINFO_RESOURCESERVER_CLIENTINFO_FLAGS_LEN 5
+#define NVDEBUG_SYSTEMINFO_RESOURCESERVER_CLIENTINFO_PRIV_LEVEL_LEN 5
+#define NVDEBUG_SYSTEMINFO_RESOURCESERVER_CLIENTINFO_ALLOCATIONS_LEN 27
+
+extern const PRB_FIELD_DESC prb_fields_nvdebug_systeminfo_resourceserver_clientinfo_clientallocation[];
+
+// 'ClientAllocation' field descriptor pointers
+#define NVDEBUG_SYSTEMINFO_RESOURCESERVER_CLIENTINFO_CLIENTALLOCATION_OBJECT_HANDLE (&prb_fields_nvdebug_systeminfo_resourceserver_clientinfo_clientallocation[0])
+#define NVDEBUG_SYSTEMINFO_RESOURCESERVER_CLIENTINFO_CLIENTALLOCATION_OBJECT_CLASS_ID (&prb_fields_nvdebug_systeminfo_resourceserver_clientinfo_clientallocation[1])
+#define NVDEBUG_SYSTEMINFO_RESOURCESERVER_CLIENTINFO_CLIENTALLOCATION_PARENT_HANDLE (&prb_fields_nvdebug_systeminfo_resourceserver_clientinfo_clientallocation[2])
+#define NVDEBUG_SYSTEMINFO_RESOURCESERVER_CLIENTINFO_CLIENTALLOCATION_GPU_INSTANCE (&prb_fields_nvdebug_systeminfo_resourceserver_clientinfo_clientallocation[3])
+
+// 'ClientAllocation' field lengths
+#define NVDEBUG_SYSTEMINFO_RESOURCESERVER_CLIENTINFO_CLIENTALLOCATION_OBJECT_HANDLE_LEN 5
+#define NVDEBUG_SYSTEMINFO_RESOURCESERVER_CLIENTINFO_CLIENTALLOCATION_OBJECT_CLASS_ID_LEN 5
+#define NVDEBUG_SYSTEMINFO_RESOURCESERVER_CLIENTINFO_CLIENTALLOCATION_PARENT_HANDLE_LEN 5
+#define NVDEBUG_SYSTEMINFO_RESOURCESERVER_CLIENTINFO_CLIENTALLOCATION_GPU_INSTANCE_LEN 5
 
 extern const PRB_SERVICE_DESC prb_services_nvdebug[];
 

--- a/src/nvidia/kernel/inc/objrpc.h
+++ b/src/nvidia/kernel/inc/objrpc.h
@@ -53,7 +53,7 @@ TYPEDEF_BITVECTOR(MC_ENGINE_BITVECTOR);
 #define RPC_TIMEOUT_LIMIT_PRINT_RATE_THRESH 3  // rate limit after 3 prints
 #define RPC_TIMEOUT_LIMIT_PRINT_RATE_SKIP   29 // skip 29 of 30 prints
 
-#define RPC_HISTORY_DEPTH 8
+#define RPC_HISTORY_DEPTH 128
 
 typedef struct RpcHistoryEntry
 {

--- a/src/nvidia/src/kernel/diagnostics/nv_debug_dump.c
+++ b/src/nvidia/src/kernel/diagnostics/nv_debug_dump.c
@@ -393,6 +393,7 @@ nvdDumpComponent_IMPL
         case NVDUMP_COMPONENT_ENG_HDA:
         case NVDUMP_COMPONENT_ENG_MSENC:
         case NVDUMP_COMPONENT_ENG_GSP:
+        case NVDUMP_COMPONENT_ENG_KGSP:
         {
             status = nvdDoEngineDump(pGpu,
                                      pNvd,

--- a/src/nvidia/src/kernel/disp/disp_sw.c
+++ b/src/nvidia/src/kernel/disp/disp_sw.c
@@ -141,8 +141,15 @@ NV_STATUS dispswReleaseSemaphoreAndNotifierFill
     NvBool     bFound = NV_FALSE;
     NV_STATUS  status;
 
+#define PRINT_INTERVAL 3600 // At 60Hz, this will emit about once per minute.
+
     if (flags & F_SEMAPHORE_ADDR_VALID)
     {
+        static NvU64 counter;
+        if ((++counter % PRINT_INTERVAL) == 0) {
+            NV_PRINTF(LEVEL_ERROR, "XXXMT: NVRM debugging - F_SEMAPHORE_ADDR_VALID = %llu\n", counter);
+        }
+
         bFound = CliGetDmaMappingInfo(RES_GET_CLIENT(pDevice),
                                       RES_GET_HANDLE(pDevice),
                                       vaSpace,
@@ -154,6 +161,11 @@ NV_STATUS dispswReleaseSemaphoreAndNotifierFill
     }
     else if (flags & F_SEMAPHORE_RELEASE)
     {
+        static NvU64 counter;
+        if ((++counter % PRINT_INTERVAL) == 0) {
+            NV_PRINTF(LEVEL_ERROR, "XXXMT: NVRM debugging - F_SEMAPHORE_RELEASE = %llu\n", counter);
+        }
+
         status =  semaphoreFillGPUVA(pGpu,
                                      pDevice,
                                      vaSpace,
@@ -165,6 +177,11 @@ NV_STATUS dispswReleaseSemaphoreAndNotifierFill
     }
     else if (flags & F_NOTIFIER_FILL)
     {
+        static NvU64 counter;
+        if ((++counter % PRINT_INTERVAL) == 0) {
+            NV_PRINTF(LEVEL_ERROR, "XXXMT: NVRM debugging - F_NOTIFIER_FILL = %llu\n", counter);
+        }
+
         status = notifyFillNotifierGPUVA(pGpu,
                                          pDevice,
                                          vaSpace,
@@ -174,6 +191,12 @@ NV_STATUS dispswReleaseSemaphoreAndNotifierFill
                                          completionStatus,
                                          NV9072_NOTIFIERS_NOTIFY_ON_VBLANK /* Index */);
         return status;
+    }
+    else {
+        static NvU64 counter;
+        if ((++counter % PRINT_INTERVAL) == 0) {
+            NV_PRINTF(LEVEL_ERROR, "XXXMT: NVRM debugging - ??? 0x%08x = %llu\n", flags, counter);
+        }
     }
     return NV9072_NOTIFICATION_STATUS_DONE_SUCCESS;
 }

--- a/src/nvidia/src/kernel/gpu/gpu_protobuf.c
+++ b/src/nvidia/src/kernel/gpu/gpu_protobuf.c
@@ -88,6 +88,10 @@ _gpuDumpEngine_CommonFields
                   NVDEBUG_ENG_GPU_IS_ACCESSIBLE,
                   pNvDumpState->bGpuAccessible);
 
+    prbEncAddUInt32(pPrbEnc,
+                    NVDEBUG_ENG_GPU_RUSD_MASK,
+                    pGpu->userSharedData.lastPolledDataMask);
+
     return rmStatus;
 }
 
@@ -136,7 +140,7 @@ gpuDumpCallbackRegister_IMPL
                         _gpuDumpEngineFunc,
                         NVDUMP_COMPONENT_ENG_GPU,
                         REF_DEF(NVD_ENGINE_FLAGS_PRIORITY, _MED) |
-                        REF_DEF(NVD_ENGINE_FLAGS_SOURCE,   _GSP),
+                        REF_DEF(NVD_ENGINE_FLAGS_SOURCE,   _BOTH),
                         (void *)pGpu);
     }
 }

--- a/src/nvidia/src/kernel/gpu/gsp/kernel_gsp.c
+++ b/src/nvidia/src/kernel/gpu/gsp/kernel_gsp.c
@@ -29,6 +29,7 @@
 #include "kernel/core/locks.h"
 #include "kernel/diagnostics/gpu_acct.h"
 #include "kernel/diagnostics/journal.h"
+#include "kernel/diagnostics/nv_debug_dump.h"
 #include "kernel/gpu/fifo/kernel_channel.h"
 #include "kernel/gpu/gsp/gsp_trace_rats_macro.h"
 #include "kernel/gpu/intr/engine_idx.h"
@@ -66,6 +67,8 @@
 #include "core/locks.h"
 #include "kernel/gpu/intr/intr.h"
 #include "kernel/gpu/gr/fecs_event_list.h"
+#include "lib/protobuf/prb_util.h"
+#include "g_nvdebug_pb.h"
 
 #define RPC_STRUCTURES
 #define RPC_GENERIC_UNION
@@ -154,6 +157,8 @@ static NV_STATUS _kgspGetSectionNameForPrefix(OBJGPU *pGpu, KernelGsp *pKernelGs
 
 static NV_STATUS _kgspRpcGspEventFecsError(OBJGPU *, OBJRPC *);
 static void _kgspRpcGspEventHandleFecsBufferError(NvU32, void *);
+
+static NV_STATUS _kgspDumpEngineFunc(OBJGPU*, PRB_ENCODER*, NVD_STATE*, void*);
 
 static void
 _kgspGetActiveRpcDebugData
@@ -333,6 +338,10 @@ _kgspCompleteRpcHistoryEntry
             pHistory[historyEntry].ts_end   == 0)
         {
             pHistory[historyEntry].ts_end = pHistory[current].ts_end;
+        }
+        else
+        {
+            break;
         }
     }
 }
@@ -1763,6 +1772,7 @@ kgspLogRpcDebugInfo
     NvU32  historyIndex;
     NvU32  historyEntry;
     NvU64  activeData[2];
+    const NvU32 rpcEntriesToLog = (RPC_HISTORY_DEPTH > 8) ? 8 : RPC_HISTORY_DEPTH;
 
     _kgspGetActiveRpcDebugData(pRpc, pMsgHdr->function,
                                &activeData[0], &activeData[1]);
@@ -1777,7 +1787,7 @@ kgspLogRpcDebugInfo
                       gpuGetInstance(pGpu));
     NV_ERROR_LOG_DATA(pGpu, errorNum,
                       "    entry function                   data0              data1              ts_start           ts_end             duration actively_polling\n");
-    for (historyIndex = 0; historyIndex < RPC_HISTORY_DEPTH; historyIndex++)
+    for (historyIndex = 0; historyIndex < rpcEntriesToLog; historyIndex++)
     {
         historyEntry = (pRpc->rpcHistoryCurrent + RPC_HISTORY_DEPTH - historyIndex) % RPC_HISTORY_DEPTH;
         _kgspLogRpcHistoryEntry(pGpu, errorNum, historyIndex, &pRpc->rpcHistory[historyEntry],
@@ -1789,7 +1799,7 @@ kgspLogRpcDebugInfo
                       gpuGetInstance(pGpu));
     NV_ERROR_LOG_DATA(pGpu, errorNum,
                       "    entry function                   data0              data1              ts_start           ts_end             duration during_incomplete_rpc\n");
-    for (historyIndex = 0; historyIndex < RPC_HISTORY_DEPTH; historyIndex++)
+    for (historyIndex = 0; historyIndex < rpcEntriesToLog; historyIndex++)
     {
         historyEntry = (pRpc->rpcEventHistoryCurrent + RPC_HISTORY_DEPTH - historyIndex) % RPC_HISTORY_DEPTH;
         _kgspLogRpcHistoryEntry(pGpu, errorNum, historyIndex, &pRpc->rpcEventHistory[historyEntry],
@@ -2748,6 +2758,28 @@ done:
 
     return nvStatus;
 }
+
+NV_STATUS kgspStateInitLocked_IMPL(OBJGPU *pGpu, KernelGsp *pKernelGsp)
+{
+    NvDebugDump *pNvd = GPU_GET_NVD(pGpu);
+    if (pNvd != NULL)
+    {
+        //
+        // Register as PRIORITY_CRITICAL so it runs sooner and we get more of the
+        // useful RPC history and not too many DUMP_COMPONENT and similar RPCs
+        // invoked by other engines' dump functions
+        //
+        nvdEngineSignUp(pGpu,
+                        pNvd,
+                        _kgspDumpEngineFunc,
+                        NVDUMP_COMPONENT_ENG_KGSP,
+                        REF_DEF(NVD_ENGINE_FLAGS_PRIORITY, _CRITICAL) |
+                        REF_DEF(NVD_ENGINE_FLAGS_SOURCE,   _CPU),
+                        (void *)pGpu);
+    }
+    return NV_OK;
+}
+
 
 /*!
  * Convert VBIOS version containing Version and OemVersion packed together to
@@ -4565,4 +4597,66 @@ NvU64 kgspGetWprEndMargin_IMPL(OBJGPU *pGpu, KernelGsp *pKernelGsp)
     // Normal boot path
     pWprMeta->flags &= ~GSP_FW_FLAGS_RECOVERY_MARGIN_PRESENT;
     return 0;
+}
+
+static NV_STATUS _kgspDumpEngineFunc
+(
+    OBJGPU *pGpu,
+    PRB_ENCODER *pPrbEnc,
+    NVD_STATE *pNvDumpState,
+    void *pvData
+)
+{
+    OBJRPC *pRpc = GPU_GET_RPC(pGpu);
+    NV_STATUS nvStatus = NV_OK;
+    NvU8 startingDepth = prbEncNestingLevel(pPrbEnc);
+
+    NV_CHECK_OK_OR_RETURN(LEVEL_ERROR,
+        prbEncNestedStart(pPrbEnc, NVDEBUG_GPUINFO_ENG_KGSP));
+
+    for (NvU32 i = 0; i < RPC_HISTORY_DEPTH; i++)
+    {
+        NvU32 entryIdx = (pRpc->rpcHistoryCurrent + RPC_HISTORY_DEPTH - i) % RPC_HISTORY_DEPTH;
+        RpcHistoryEntry *entry = &pRpc->rpcHistory[entryIdx];
+
+        if (entry->function == 0)
+            break;
+
+        NV_CHECK_OK_OR_RETURN(LEVEL_ERROR,
+            prbEncNestedStart(pPrbEnc, NVDEBUG_ENG_KGSP_RPC_HISTORY));
+
+        prbEncAddUInt32(pPrbEnc, NVDEBUG_ENG_KGSP_RPCINFO_FUNCTION, entry->function);
+        prbEncAddUInt64(pPrbEnc, NVDEBUG_ENG_KGSP_RPCINFO_TS_START, entry->ts_start);
+        prbEncAddUInt64(pPrbEnc, NVDEBUG_ENG_KGSP_RPCINFO_TS_END, entry->ts_end);
+        prbEncAddUInt32(pPrbEnc, NVDEBUG_ENG_KGSP_RPCINFO_DATA0, entry->data[0]);
+        prbEncAddUInt32(pPrbEnc, NVDEBUG_ENG_KGSP_RPCINFO_DATA1, entry->data[1]);
+
+        prbEncNestedEnd(pPrbEnc);
+    }
+
+    for (NvU32 i = 0; i < RPC_HISTORY_DEPTH; i++)
+    {
+        NvU32 entryIdx = (pRpc->rpcEventHistoryCurrent + RPC_HISTORY_DEPTH - i) % RPC_HISTORY_DEPTH;
+        RpcHistoryEntry *entry = &pRpc->rpcEventHistory[entryIdx];
+
+        if (entry->function == 0)
+            break;
+
+        NV_CHECK_OK_OR_RETURN(LEVEL_ERROR,
+            prbEncNestedStart(pPrbEnc, NVDEBUG_ENG_KGSP_EVENT_HISTORY));
+
+        prbEncAddUInt32(pPrbEnc, NVDEBUG_ENG_KGSP_RPCINFO_FUNCTION, entry->function);
+        prbEncAddUInt64(pPrbEnc, NVDEBUG_ENG_KGSP_RPCINFO_TS_START, entry->ts_start);
+        prbEncAddUInt64(pPrbEnc, NVDEBUG_ENG_KGSP_RPCINFO_TS_END, entry->ts_end);
+        prbEncAddUInt32(pPrbEnc, NVDEBUG_ENG_KGSP_RPCINFO_DATA0, entry->data[0]);
+        prbEncAddUInt32(pPrbEnc, NVDEBUG_ENG_KGSP_RPCINFO_DATA1, entry->data[1]);
+
+        prbEncNestedEnd(pPrbEnc);
+    }
+
+    // Unwind the protobuf to the correct depth.
+    NV_CHECK_OK_OR_CAPTURE_FIRST_ERROR(nvStatus, LEVEL_ERROR,
+        prbEncUnwindNesting(pPrbEnc, startingDepth));
+
+    return nvStatus;
 }


### PR DESCRIPTION
# This is not a pull request.

Just publishing my side branch here to have a centralized place to test and discuss these patches.

We've been having reports of stutter issues in 555 releases related to GSP enablement. On the proprietary driver, `NVreg_EnableGpuFirmware=0` makes them go away; on the open driver that's not an option.

So far, we've identified two possible causes here. One is fixed by commit 674c009 below. The other we can't fix/workaround in the kernel modules and requires usermode changes, but commit 8c1c49b should tell us if that path is actually being hit or not.

I've also augmented the logs captured by nvidia-bug-report.sh with some of the info that we found severely lacking in the bug reports so far.

My hope is that folks that have experienced these stutter issues can take these patches, try to reproduce the issue and report back with their findings (and their nvidia-bug-report logs). Many thanks in advance to anyone willing to go the extra mile(s) for us here!

We've unfortunately missed beta2 / 555.52 with this stuff (security fixes can't wait), but here it is early so we don't have to wait on the next release.