### PR TITLE
[backport] Prevent undefined behavior

### DIFF
--- a/src/nvidia/src/libraries/libspdm/2.3.1/include/internal/libspdm_common_lib.h
+++ b/src/nvidia/src/libraries/libspdm/2.3.1/include/internal/libspdm_common_lib.h
@@ -14,6 +14,8 @@
 #include "library/spdm_device_secret_lib.h"
 
 #define INVALID_SESSION_ID 0
+#define LIBSPDM_MAX_CT_EXPONENT 31
+#define LIBSPDM_MAX_RDT_EXPONENT 31
 
 typedef struct {
     uint8_t spdm_version_count;

--- a/src/nvidia/src/libraries/libspdm/2.3.1/library/spdm_requester_lib/libspdm_req_get_capabilities.c
+++ b/src/nvidia/src/libraries/libspdm/2.3.1/library/spdm_requester_lib/libspdm_req_get_capabilities.c
@@ -279,6 +279,11 @@ static libspdm_return_t libspdm_try_get_capabilities(libspdm_context_t *spdm_con
         }
     }
 
+    if (spdm_response->ct_exponent > LIBSPDM_MAX_CT_EXPONENT) {
+        status = LIBSPDM_STATUS_INVALID_MSG_FIELD;
+        goto receive_done;
+    }
+
     /* -=[Process Response Phase]=- */
     status = libspdm_append_message_a(spdm_context, spdm_request, spdm_request_size);
     if (LIBSPDM_STATUS_IS_ERROR(status)) {

--- a/src/nvidia/src/libraries/libspdm/2.3.1/library/spdm_requester_lib/libspdm_req_handle_error_response.c
+++ b/src/nvidia/src/libraries/libspdm/2.3.1/library/spdm_requester_lib/libspdm_req_handle_error_response.c
@@ -167,13 +167,16 @@ static libspdm_return_t libspdm_handle_response_not_ready(libspdm_context_t *spd
     if (extend_error_data->request_code != original_request_code) {
         return LIBSPDM_STATUS_INVALID_MSG_FIELD;
     }
+    if (extend_error_data->rd_exponent > LIBSPDM_MAX_RDT_EXPONENT) {
+        return LIBSPDM_STATUS_INVALID_MSG_FIELD;
+    }
 
     spdm_context->error_data.rd_exponent = extend_error_data->rd_exponent;
     spdm_context->error_data.request_code = extend_error_data->request_code;
     spdm_context->error_data.token = extend_error_data->token;
     spdm_context->error_data.rd_tm = extend_error_data->rd_tm;
 
-    libspdm_sleep_in_us((2 << extend_error_data->rd_exponent));
+    libspdm_sleep_in_us((uint64_t)1 << extend_error_data->rd_exponent);
     return libspdm_requester_respond_if_ready(spdm_context, session_id,
                                               response_size, response,
                                               expected_response_code,

--- a/src/nvidia/src/libraries/libspdm/2.3.1/library/spdm_requester_lib/libspdm_req_send_receive.c
+++ b/src/nvidia/src/libraries/libspdm/2.3.1/library/spdm_requester_lib/libspdm_req_send_receive.c
@@ -130,7 +130,7 @@ libspdm_return_t libspdm_receive_response(void *context, const uint32_t *session
 
     if (spdm_context->crypto_request) {
         timeout = spdm_context->local_context.capability.rtt +
-                  ((uint64_t)2 << spdm_context->connection_info.capability.ct_exponent);
+                  ((uint64_t)1 << spdm_context->connection_info.capability.ct_exponent);
     } else {
         timeout = spdm_context->local_context.capability.rtt +
                   spdm_context->local_context.capability.st1;


### PR DESCRIPTION
Here is a vulnerability CVE-2023-32690 in [libspdm](https://github.com/DMTF/libspdm) and you fix it in the main branch and 550 branch. Maybe it need to be backported to the 545.23 branch?