### PR TITLE
Fix broken ELD files with mangled `monitor_name` when using HDMI

### DIFF
--- a/src/nvidia-modeset/src/nvkms-hdmi.c
+++ b/src/nvidia-modeset/src/nvkms-hdmi.c
@@ -1032,6 +1032,30 @@ static NvBool FillELDBuffer(const NVDpyEvoRec *pDpyEvo,
      * string in the EDID is terminated with 0x0A and padded with 0x20.
      * We do not keep the special characters.
      */
+    if (status == NVT_STATUS_SUCCESS) {
+        /*
+         * NvTiming_GetProductName() returns a nul-terminated string, but the
+         * string in the EDID is terminated with 0x0A and padded with 0x20.
+         * Put back these special characters.
+         */
+//        NvBool pastTerminator = FALSE;
+        NvU32 i;
+
+//        for (i = 0; i < NVT_EDID_LDD_PAYLOAD_SIZE; i++) {
+//            if (pastTerminator) {
+//                name[i] = 0x20;
+//            }
+//            if (name[i] == '\0') {
+//                name[i] = 0x0A;
+//                pastTerminator = TRUE;
+//            }
+//        }
+
+        monitorNameLen = NVT_EDID_LDD_PAYLOAD_SIZE;
+        pEld->buffer[4] |= NVT_EDID_LDD_PAYLOAD_SIZE;
+        nvkms_memcpy(&pEld->buffer[20], name,
+                     NVT_EDID_LDD_PAYLOAD_SIZE);
+    }
 
     /* offset 20 + MNL ~ 20 + MNL + (3 * SAD_Count) - 1 : CEA_SADs */
     if (SADCount) {

--- a/src/nvidia-modeset/src/nvkms-hdmi.c
+++ b/src/nvidia-modeset/src/nvkms-hdmi.c
@@ -1027,6 +1027,7 @@ static NvBool FillELDBuffer(const NVDpyEvoRec *pDpyEvo,
     monitorNameLen = 0;
 
     status = NvTiming_GetProductName(&pParsedEdid->info, name, sizeof(name));
+
     if (status == NVT_STATUS_SUCCESS) {
         /*
          * NvTiming_GetProductName() returns a nul-terminated string, but the

--- a/src/nvidia-modeset/src/nvkms-hdmi.c
+++ b/src/nvidia-modeset/src/nvkms-hdmi.c
@@ -151,7 +151,7 @@ static void CalculateVideoInfoFrameColorFormat(
 }
 
 /*
- * GetHDMISupportCap() - find the HDMI capabilities of
+ * GetHDMISupportCap() - find the HDMI capabilities of 
  * the gpu and the display device.
  */
 
@@ -1030,22 +1030,10 @@ static NvBool FillELDBuffer(const NVDpyEvoRec *pDpyEvo,
     if (status == NVT_STATUS_SUCCESS) {
         /*
          * NvTiming_GetProductName() returns a nul-terminated string, but the
-         * string in the EDID is terminated with 0x0A and padded with 0x20.
-         * Put back these special characters.
+         * string in the EDID is originally terminated with 0x0A and padded
+         * with 0x20.
+         * We removed the special characters to not break the resulting eld.
          */
-//        NvBool pastTerminator = FALSE;
-//        NvU32 i;
-
-//        for (i = 0; i < NVT_EDID_LDD_PAYLOAD_SIZE; i++) {
-//            if (pastTerminator) {
-//                name[i] = 0x20;
-//            }
-//            if (name[i] == '\0') {
-//                name[i] = 0x0A;
-//                pastTerminator = TRUE;
-//            }
-//        }
-
         monitorNameLen = NVT_EDID_LDD_PAYLOAD_SIZE;
         pEld->buffer[4] |= NVT_EDID_LDD_PAYLOAD_SIZE;
         nvkms_memcpy(&pEld->buffer[20], name,

--- a/src/nvidia-modeset/src/nvkms-hdmi.c
+++ b/src/nvidia-modeset/src/nvkms-hdmi.c
@@ -1039,7 +1039,7 @@ static NvBool FillELDBuffer(const NVDpyEvoRec *pDpyEvo,
          * Put back these special characters.
          */
 //        NvBool pastTerminator = FALSE;
-        NvU32 i;
+//        NvU32 i;
 
 //        for (i = 0; i < NVT_EDID_LDD_PAYLOAD_SIZE; i++) {
 //            if (pastTerminator) {

--- a/src/nvidia-modeset/src/nvkms-hdmi.c
+++ b/src/nvidia-modeset/src/nvkms-hdmi.c
@@ -1027,31 +1027,11 @@ static NvBool FillELDBuffer(const NVDpyEvoRec *pDpyEvo,
     monitorNameLen = 0;
 
     status = NvTiming_GetProductName(&pParsedEdid->info, name, sizeof(name));
-
-    if (status == NVT_STATUS_SUCCESS) {
-        /*
-         * NvTiming_GetProductName() returns a nul-terminated string, but the
-         * string in the EDID is terminated with 0x0A and padded with 0x20.
-         * Put back these special characters.
-         */
-        NvBool pastTerminator = FALSE;
-        NvU32 i;
-
-        for (i = 0; i < NVT_EDID_LDD_PAYLOAD_SIZE; i++) {
-            if (pastTerminator) {
-                name[i] = 0x20;
-            }
-            if (name[i] == '\0') {
-                name[i] = 0x0A;
-                pastTerminator = TRUE;
-            }
-        }
-
-        monitorNameLen = NVT_EDID_LDD_PAYLOAD_SIZE;
-        pEld->buffer[4] |= NVT_EDID_LDD_PAYLOAD_SIZE;
-        nvkms_memcpy(&pEld->buffer[20], name,
-                     NVT_EDID_LDD_PAYLOAD_SIZE);
-    }
+    /*
+     * NvTiming_GetProductName() returns a nul-terminated string, but the
+     * string in the EDID is terminated with 0x0A and padded with 0x20.
+     * We do not keep the special characters.
+     */
 
     /* offset 20 + MNL ~ 20 + MNL + (3 * SAD_Count) - 1 : CEA_SADs */
     if (SADCount) {

--- a/src/nvidia-modeset/src/nvkms-hdmi.c
+++ b/src/nvidia-modeset/src/nvkms-hdmi.c
@@ -151,7 +151,7 @@ static void CalculateVideoInfoFrameColorFormat(
 }
 
 /*
- * GetHDMISupportCap() - find the HDMI capabilities of 
+ * GetHDMISupportCap() - find the HDMI capabilities of
  * the gpu and the display device.
  */
 
@@ -1027,11 +1027,6 @@ static NvBool FillELDBuffer(const NVDpyEvoRec *pDpyEvo,
     monitorNameLen = 0;
 
     status = NvTiming_GetProductName(&pParsedEdid->info, name, sizeof(name));
-    /*
-     * NvTiming_GetProductName() returns a nul-terminated string, but the
-     * string in the EDID is terminated with 0x0A and padded with 0x20.
-     * We do not keep the special characters.
-     */
     if (status == NVT_STATUS_SUCCESS) {
         /*
          * NvTiming_GetProductName() returns a nul-terminated string, but the


### PR DESCRIPTION
The Nvidia driver, both open and proprietary, currently pads the `monitor_name` of HDMI devices with newlines and extra spaces in the generated ELDs.   

This ends up breaking both PipeWire and Pulseaudio at minimum, see the [downstream report](https://gitlab.freedesktop.org/pipewire/pipewire/-/issues/4332) which is worked around by [this PipeWire PR](https://gitlab.freedesktop.org/pipewire/pipewire/-/merge_requests/2139).

The issue is easily verified by checking either the ELD files directly, or `device.product.name` from Pulse tools (provided they do not contain the workaround patch above), which rely on the ELD.

Based on what I could find by scourging public pastebins, and asking people around for outputs, only Nvidia has this issue, and only for HDMI device product names.

Pre-patch `cat /proc/asound/NVidia/eld\#0.*` which have a newline and spaces in them:
![image](https://github.com/user-attachments/assets/9b8fa7f5-ee1e-44ef-aeeb-25ebac75ab88)  
*Line 7, which is only there due to the extra `\n`, has the extra spaces*

Pre-patch:
```bash
[130] % pactl --format=json list cards | python -m json.tool | grep '\\n'
                    "device.product.name": "27QHD240\n    "
                    "device.product.name": "ASUS MG279\n  "
```

Post-patch:
```bash
[0] % pactl --format=json list cards | python -m json.tool | grep 'ASUS'
                    "device.product.name": "ASUS MG279"
```

Out of curiosity, how long has this been in the driver?  

I can only tell that it's been in the open source init that goes back 2 years.

---

*I am not a C developer, please have mercy if there is some glaring issue.*

*I am assuming my commits will be squashed before merge, they're a mess.*