### PR TITLE
nvidia-drm: nvidia-drm-drv: Remove .date from nv_drm_driver

### DIFF
--- a/kernel-open/nvidia-drm/nvidia-drm-drv.c
+++ b/kernel-open/nvidia-drm/nvidia-drm-drv.c
@@ -1915,7 +1915,6 @@ static struct drm_driver nv_drm_driver = {
     .name                   = "nvidia-drm",
 
     .desc                   = "NVIDIA DRM driver",
-    .date                   = "20160202",
 
 #if defined(NV_DRM_DRIVER_HAS_DEVICE_LIST)
     .device_list            = LIST_HEAD_INIT(nv_drm_driver.device_list),


### PR DESCRIPTION
The `date` member in `struct drm_driver` has been deprecated since Linux v6.9

	Upstream Commit: 7fb8af6798e8 ("drm: deprecate driver date")

and the IOCTL that exposed it DRM_IOCTL_VERSION, returns an empty string since then.

Furthermore this member was completely removed from all upstream DRM drivers since

	Upstream Commit: cb2e1c2136f7 ("drm: remove driver date from struct drm_driver and all drivers")

which fixes the following compilation error on Linux v6.14-rc1:

```
nvidia-drm/nvidia-drm-drv.c:1918:6: error: ‘struct drm_driver’ has no member named ‘date’
 1918 |     .date                   = "20160202",
      |      ^~~~
nvidia-drm/nvidia-drm-drv.c:1918:31: error: initialization of ‘unsigned int’ from ‘char *’ makes integer from pointer without a cast [-Wint-conversion]
 1918 |     .date                   = "20160202",
      |                               ^~~~~~~~~~
```