### PR TITLE
removing .date from nvidia-drm-drv.c

### DIFF
--- a/kernel-open/nvidia-drm/nvidia-drm-drv.c
+++ b/kernel-open/nvidia-drm/nvidia-drm-drv.c
@@ -1915,7 +1915,10 @@ static struct drm_driver nv_drm_driver = {
     .name                   = "nvidia-drm",
 
     .desc                   = "NVIDIA DRM driver",
-    .date                   = "20160202",
+/*Nicolas Baranger 20250213 */
+/*Removing '.date' because it had been removed from struct drm_driver in linux-6.14 */
+/*see https://github.com/torvalds/linux/commit/cb2e1c2136f71618142557ceca3a8802e87a44cd */
+/*    .date                   = "20160202", */
 
 #if defined(NV_DRM_DRIVER_HAS_DEVICE_LIST)
     .device_list            = LIST_HEAD_INIT(nv_drm_driver.device_list),


### PR DESCRIPTION
error: ‘struct drm_driver’ has no member named ‘date’

DATE field had been totally removed from mainline Linux kernel (linux-6.14-rc). 
See commit https://github.com/torvalds/linux/commit/cb2e1c2136f71618142557ceca3a8802e87a44cd 
This change had to be done on proprietary drivers too (e.g nvidia-550.144.03)