### PR TITLE
nvidia-drm: Add support for kernel 6.17 drm_helper_mode_fill_fb_struct API

### DIFF
--- a/kernel-open/conftest.sh
+++ b/kernel-open/conftest.sh
@@ -4819,6 +4819,28 @@ compile_test() {
             compile_check_conftest "$CODE" "NV_DRM_CONNECTOR_HELPER_FUNCS_MODE_VALID_HAS_CONST_MODE_ARG" "" "types"
         ;;
 
+        drm_helper_mode_fill_fb_struct_has_info_arg)
+            #
+            # Determine if drm_helper_mode_fill_fb_struct() takes the info argument.
+            #
+            # The drm_helper_mode_fill_fb_struct() function was updated to take
+            # a const struct drm_format_info * argument by kernel commit
+            # a34cc7bf1034 ("drm: Allow the caller to pass in the format info
+            # to drm_helper_mode_fill_fb_struct()") in v6.17.
+            #
+            CODE="
+            #include <drm/drm_modeset_helper.h>
+            void conftest_drm_helper_mode_fill_fb_struct(void) {
+                struct drm_device *dev = NULL;
+                struct drm_framebuffer *fb = NULL;
+                const struct drm_format_info *info = NULL;
+                const struct drm_mode_fb_cmd2 *cmd = NULL;
+                drm_helper_mode_fill_fb_struct(dev, fb, info, cmd);
+            }"
+
+            compile_check_conftest "$CODE" "NV_DRM_HELPER_MODE_FILL_FB_STRUCT_HAS_INFO_ARG" "" "functions"
+        ;;
+
         # When adding a new conftest entry, please use the correct format for
         # specifying the relevant upstream Linux kernel commit.  Please
         # avoid specifying -rc kernels, and only use SHAs that actually exist

--- a/kernel-open/nvidia-drm/nvidia-drm-fb.h
+++ b/kernel-open/nvidia-drm/nvidia-drm-fb.h
@@ -50,10 +50,18 @@ static inline struct nv_drm_framebuffer *to_nv_framebuffer(
     return container_of(fb, struct nv_drm_framebuffer, base);
 }
 
+#if !defined(NV_DRM_HELPER_MODE_FILL_FB_STRUCT_HAS_INFO_ARG)
 struct drm_framebuffer *nv_drm_framebuffer_create(
     struct drm_device *dev,
     struct drm_file *file,
     const struct drm_mode_fb_cmd2 *cmd);
+#else
+struct drm_framebuffer *nv_drm_framebuffer_create(
+    struct drm_device *dev,
+    struct drm_file *file,
+    const struct drm_format_info *info,
+    const struct drm_mode_fb_cmd2 *cmd);
+#endif
 
 #endif /* NV_DRM_AVAILABLE */
 

--- a/kernel-open/nvidia-drm/nvidia-drm-sources.mk
+++ b/kernel-open/nvidia-drm/nvidia-drm-sources.mk
@@ -62,6 +62,7 @@ NV_CONFTEST_FUNCTION_COMPILE_TESTS += drm_plane_create_color_properties
 NV_CONFTEST_FUNCTION_COMPILE_TESTS += drm_atomic_helper_legacy_gamma_set
 NV_CONFTEST_FUNCTION_COMPILE_TESTS += vmf_insert_mixed
 NV_CONFTEST_FUNCTION_COMPILE_TESTS += drm_gem_prime_mmap
+NV_CONFTEST_FUNCTION_COMPILE_TESTS += drm_helper_mode_fill_fb_struct_has_info_arg
 
 NV_CONFTEST_TYPE_COMPILE_TESTS += drm_driver_has_legacy_dev_list
 NV_CONFTEST_TYPE_COMPILE_TESTS += vm_ops_fault_removed_vma_arg


### PR DESCRIPTION
The drm_helper_mode_fill_fb_struct() function signature changed in Linux kernel 6.17 to include a const struct drm_format_info * parameter. This was introduced by kernel commit [a34cc7bf1034](https://github.com/torvalds/linux/commit/a34cc7bf1034280904f9683e260f9d9e9fd4b84f) ("drm: Allow the caller to pass in the format info to drm_helper_mode_fill_fb_struct()").

This adds a conftest function and NV_DRM_HELPER_MODE_FILL_FB_STRUCT_HAS_INFO_ARG macro to use the new drm_format_info logic and signature.