### PR TITLE
Update "extract-firmware-nouveau" utilities

### DIFF
--- a/nouveau/extract-firmware-nouveau.py
+++ b/nouveau/extract-firmware-nouveau.py
@@ -120,6 +120,7 @@ def bootloader(gpu, fuse):
     global version
 
     GPU = gpu.upper()
+    FUSE = fuse.upper()
     filename = f"src/nvidia/generated/g_bindata_kgspGetBinArchiveGspRmBoot_{GPU}.c"
 
     print(f"Creating nvidia/{gpu}/gsp/bootloader-{version}.bin")
@@ -127,12 +128,12 @@ def bootloader(gpu, fuse):
 
     with open(f"{outputpath}/nvidia/{gpu}/gsp/bootloader-{version}.bin", "wb") as f:
         # Extract the actual bootloader firmware
-        array = f"kgspBinArchiveGspRmBoot_{GPU}_ucode_image{fuse}data"
+        array = f"kgspBinArchiveGspRmBoot_{GPU}_BINDATA_LABEL_UCODE_IMAGE{FUSE}data"
         firmware = getbytes(filename, array)
         firmware_size = len(firmware)
 
         # Extract the descriptor (RM_RISCV_UCODE_DESC)
-        array = f"kgspBinArchiveGspRmBoot_{GPU}_ucode_desc{fuse}data"
+        array = f"kgspBinArchiveGspRmBoot_{GPU}_BINDATA_LABEL_UCODE_DESC{FUSE}data"
         descriptor = getbytes(filename, array)
         descriptor_size = len(descriptor)
 
@@ -154,6 +155,7 @@ def booter(gpu, load, sigsize, fuse = "prod"):
 
     GPU = gpu.upper()
     LOAD = load.capitalize()
+    FUSE = fuse.upper()
 
     filename = f"src/nvidia/generated/g_bindata_kgspGetBinArchiveBooter{LOAD}Ucode_{GPU}.c"
 
@@ -162,12 +164,12 @@ def booter(gpu, load, sigsize, fuse = "prod"):
 
     with open(f"{outputpath}/nvidia/{gpu}/gsp/booter_{load}-{version}.bin", "wb") as f:
         # Extract the actual booter firmware
-        array = f"kgspBinArchiveBooter{LOAD}Ucode_{GPU}_image_{fuse}_data"
+        array = f"kgspBinArchiveBooter{LOAD}Ucode_{GPU}_BINDATA_LABEL_IMAGE_{FUSE}_data"
         firmware = getbytes(filename, array)
         firmware_size = len(firmware)
 
         # Extract the signatures
-        array = f"kgspBinArchiveBooter{LOAD}Ucode_{GPU}_sig_{fuse}_data"
+        array = f"kgspBinArchiveBooter{LOAD}Ucode_{GPU}_BINDATA_LABEL_SIG_{FUSE}_data"
         signatures = getbytes(filename, array)
         signatures_size = len(signatures)
         if signatures_size % sigsize:
@@ -195,12 +197,12 @@ def booter(gpu, load, sigsize, fuse = "prod"):
         f.write(signatures)
 
         # Extract the patch location
-        array = f"kgspBinArchiveBooter{LOAD}Ucode_{GPU}_patch_loc_data"
+        array = f"kgspBinArchiveBooter{LOAD}Ucode_{GPU}_BINDATA_LABEL_PATCH_LOC_data"
         bytes = getbytes(filename, array)
         patchloc = struct.unpack("<L", bytes)[0]
 
         # Extract the patch meta variables
-        array = f"kgspBinArchiveBooter{LOAD}Ucode_{GPU}_patch_meta_data"
+        array = f"kgspBinArchiveBooter{LOAD}Ucode_{GPU}_BINDATA_LABEL_PATCH_META_data"
         bytes = getbytes(filename, array)
         fuse_ver, engine_id, ucode_id = struct.unpack("<LLL", bytes)
 
@@ -208,7 +210,7 @@ def booter(gpu, load, sigsize, fuse = "prod"):
         f.write(struct.pack("<6L", patchloc, 0, fuse_ver, engine_id, ucode_id, num_sigs))
 
         # Extract the descriptor (nvkm_gsp_booter_fw_hdr)
-        array = f"kgspBinArchiveBooter{LOAD}Ucode_{GPU}_header_{fuse}_data"
+        array = f"kgspBinArchiveBooter{LOAD}Ucode_{GPU}_BINDATA_LABEL_HEADER_{FUSE}_data"
         descriptor = getbytes(filename, array)
 
         # Fifth, the descriptor
@@ -225,7 +227,7 @@ def scrubber(gpu, sigsize, fuse = "prod"):
     # Unfortunately, RM breaks convention with the scrubber image and labels
     # the files and arrays with AD10X instead of AD102.
     GPUX = f"{gpu[:-1].upper()}X"
-
+    FUSE = fuse.upper()
     filename = f"src/nvidia/generated/g_bindata_ksec2GetBinArchiveSecurescrubUcode_{GPUX}.c"
 
     print(f"Creating nvidia/{gpu}/gsp/scrubber-{version}.bin")
@@ -233,12 +235,12 @@ def scrubber(gpu, sigsize, fuse = "prod"):
 
     with open(f"{outputpath}/nvidia/{gpu}/gsp/scrubber-{version}.bin", "wb") as f:
         # Extract the actual scrubber firmware
-        array = f"ksec2BinArchiveSecurescrubUcode_{GPUX}_image_{fuse}_data[]"
+        array = f"ksec2BinArchiveSecurescrubUcode_{GPUX}_BINDATA_LABEL_IMAGE_{FUSE}_data[]"
         firmware = getbytes(filename, array)
         firmware_size = len(firmware)
 
         # Extract the signatures
-        array = f"ksec2BinArchiveSecurescrubUcode_{GPUX}_sig_{fuse}_data"
+        array = f"ksec2BinArchiveSecurescrubUcode_{GPUX}_BINDATA_LABEL_SIG_{FUSE}_data"
         signatures = getbytes(filename, array)
         signatures_size = len(signatures)
         if signatures_size % sigsize:
@@ -266,12 +268,12 @@ def scrubber(gpu, sigsize, fuse = "prod"):
         f.write(signatures)
 
         # Extract the patch location
-        array = f"ksec2BinArchiveSecurescrubUcode_{GPUX}_patch_loc_data"
+        array = f"ksec2BinArchiveSecurescrubUcode_{GPUX}_BINDATA_LABEL_PATCH_LOC_data"
         bytes = getbytes(filename, array)
         patchloc = struct.unpack("<L", bytes)[0]
 
         # Extract the patch meta variables
-        array = f"ksec2BinArchiveSecurescrubUcode_{GPUX}_patch_meta_data"
+        array = f"ksec2BinArchiveSecurescrubUcode_{GPUX}_BINDATA_LABEL_PATCH_META_data"
         bytes = getbytes(filename, array)
         fuse_ver, engine_id, ucode_id = struct.unpack("<LLL", bytes)
 
@@ -279,7 +281,7 @@ def scrubber(gpu, sigsize, fuse = "prod"):
         f.write(struct.pack("<6L", patchloc, 0, fuse_ver, engine_id, ucode_id, num_sigs))
 
         # Extract the descriptor (nvkm_gsp_booter_fw_hdr)
-        array = f"ksec2BinArchiveSecurescrubUcode_{GPUX}_header_{fuse}_data"
+        array = f"ksec2BinArchiveSecurescrubUcode_{GPUX}_BINDATA_LABEL_HEADER_{FUSE}_data"
         descriptor = getbytes(filename, array)
 
         # Fifth, the descriptor
@@ -395,19 +397,19 @@ def fmc(gpu, fuse = "Prod"):
     print(f"Creating nvidia/{gpu}/gsp/fmc-{version}.bin")
     os.makedirs(f"{outputpath}/nvidia/{gpu}/gsp/", exist_ok = True)
 
-    array = f"kgspBinArchiveGspRmFmcGfw{fuse}Signed_{GPU}_ucode_hash_data"
+    array = f"kgspBinArchiveGspRmFmcGfw{fuse}Signed_{GPU}_BINDATA_LABEL_UCODE_HASH_data"
     ucode_hash = getbytes(filename, array)
     (ucode_hash_size, ucode_hash_padded_size) = sizes(ucode_hash)
 
-    array = f"kgspBinArchiveGspRmFmcGfw{fuse}Signed_{GPU}_ucode_sig_data"
+    array = f"kgspBinArchiveGspRmFmcGfw{fuse}Signed_{GPU}_BINDATA_LABEL_UCODE_SIG_data"
     ucode_sig = getbytes(filename, array)
     (ucode_sig_size, ucode_sig_padded_size) = sizes(ucode_sig)
 
-    array = f"kgspBinArchiveGspRmFmcGfw{fuse}Signed_{GPU}_ucode_pkey_data"
+    array = f"kgspBinArchiveGspRmFmcGfw{fuse}Signed_{GPU}_BINDATA_LABEL_UCODE_PKEY_data"
     ucode_pkey = getbytes(filename, array)
     (ucode_pkey_size, ucode_pkey_padded_size) = sizes(ucode_pkey)
 
-    array = f"kgspBinArchiveGspRmFmcGfw{fuse}Signed_{GPU}_ucode_image_data"
+    array = f"kgspBinArchiveGspRmFmcGfw{fuse}Signed_{GPU}_BINDATA_LABEL_UCODE_IMAGE_data"
     ucode_image = getbytes(filename, array)
     (ucode_image_size, ucode_image_padded_size) = sizes(ucode_image)
 

--- a/nouveau/extract-firmware-nouveau/src/main.rs
+++ b/nouveau/extract-firmware-nouveau/src/main.rs
@@ -404,6 +404,7 @@ fn round_up_to_base(x: u32, base: u32) -> u32 {
 
 fn bootloader(output: &Path, version: &str, gpu: &str, prod: &str) -> Result<(), String> {
     let gpu_upper = gpu.to_uppercase();
+    let prod_upper = prod.to_uppercase();
     let filename = PathBuf::from(format!(
         "src/nvidia/generated/g_bindata_kgspGetBinArchiveGspRmBoot_{gpu_upper}.c"
     ));
@@ -415,12 +416,12 @@ fn bootloader(output: &Path, version: &str, gpu: &str, prod: &str) -> Result<(),
         .map_err(|err| format!("Could not create nvidia/{gpu}/gsp/: {err}"))?;
 
     // Extract the actual bootloader firmware
-    let array = format!("kgspBinArchiveGspRmBoot_{gpu_upper}_ucode_image_{prod}data");
+    let array = format!("kgspBinArchiveGspRmBoot_{gpu_upper}_BINDATA_LABEL_UCODE_IMAGE_{prod_upper}data");
     let firmware = get_bytes(&filename, &array, None)?;
     let firmware_size: u32 = firmware.len() as u32;
 
     // Extract the descriptor (RM_RISCV_UCODE_DESC)
-    let array = format!("kgspBinArchiveGspRmBoot_{gpu_upper}_ucode_desc_{prod}data");
+    let array = format!("kgspBinArchiveGspRmBoot_{gpu_upper}_BINDATA_LABEL_UCODE_DESC_{prod_upper}data");
     let descriptor = get_bytes(&filename, &array, None)?;
     let descriptor_size: u32 = descriptor.len() as u32;
 
@@ -486,12 +487,12 @@ fn booter(output: &Path, version: &str, gpu: &str, load: &str, sigsize: u32) -> 
         .map_err(|err| format!("Could not create nvidia/{gpu}/gsp/: {err}"))?;
 
     // Extract the actual booter firmware
-    let array = format!("kgspBinArchiveBooter{load_upper}Ucode_{gpu_upper}_image_prod_data");
+    let array = format!("kgspBinArchiveBooter{load_upper}Ucode_{gpu_upper}_BINDATA_LABEL_IMAGE_PROD_data");
     let firmware = get_bytes(&filename, &array, None)?;
     let firmware_size = firmware.len() as u32;
 
     // Extract the signatures
-    let array = format!("kgspBinArchiveBooter{load_upper}Ucode_{gpu_upper}_sig_prod_data");
+    let array = format!("kgspBinArchiveBooter{load_upper}Ucode_{gpu_upper}_BINDATA_LABEL_SIG_PROD_data");
     let signatures = get_bytes(&filename, &array, None)?;
     let signatures_size = signatures.len() as u32;
     if (signatures_size % sigsize) != 0 {
@@ -503,12 +504,12 @@ fn booter(output: &Path, version: &str, gpu: &str, load: &str, sigsize: u32) -> 
     }
 
     // Extract the patch location
-    let array = format!("kgspBinArchiveBooter{load_upper}Ucode_{gpu_upper}_patch_loc_data");
+    let array = format!("kgspBinArchiveBooter{load_upper}Ucode_{gpu_upper}_BINDATA_LABEL_PATCH_LOC_data");
     let patch_loc_data = get_bytes(&filename, &array, Some(4))?;
     let patch_loc = LittleEndian::read_u32(&patch_loc_data);
 
     // Extract the patch meta variables
-    let array = format!("kgspBinArchiveBooter{load_upper}Ucode_{gpu_upper}_patch_meta_data");
+    let array = format!("kgspBinArchiveBooter{load_upper}Ucode_{gpu_upper}_BINDATA_LABEL_PATCH_META_data");
     let patch_meta_data = get_bytes(&filename, &array, Some(12))?;
 
     let (fuse_ver, engine_id, ucode_id) = patch_meta_data
@@ -569,7 +570,7 @@ fn booter(output: &Path, version: &str, gpu: &str, load: &str, sigsize: u32) -> 
         .map_err(|err| format!("Could not write to {}: {err}", filename.display()))?;
 
     // Extract the descriptor (nvkm_gsp_booter_fw_hdr)
-    let array = format!("kgspBinArchiveBooter{load_upper}Ucode_{gpu_upper}_header_prod_data");
+    let array = format!("kgspBinArchiveBooter{load_upper}Ucode_{gpu_upper}_BINDATA_LABEL_HEADER_PROD_data");
     let descriptor = get_bytes(&filename, &array, Some(36))?;
 
     // Fifth, the descriptor
@@ -603,12 +604,12 @@ fn scrubber(output: &Path, version: &str, gpu: &str, sigsize: u32) -> Result<(),
         .map_err(|err| format!("Could not create nvidia/{gpu}/gsp/: {err}"))?;
 
     // Extract the actual scrubber firmware
-    let array = format!("ksec2BinArchiveSecurescrubUcode_{gpux}_image_prod_data");
+    let array = format!("ksec2BinArchiveSecurescrubUcode_{gpux}_BINDATA_LABEL_IMAGE_PROD_data");
     let firmware = get_bytes(&filename, &array, None)?;
     let firmware_size = firmware.len() as u32;
 
     // Extract the signatures
-    let array = format!("ksec2BinArchiveSecurescrubUcode_{gpux}_sig_prod_data");
+    let array = format!("ksec2BinArchiveSecurescrubUcode_{gpux}_BINDATA_LABEL_SIG_PROD_data");
     let signatures = get_bytes(&filename, &array, None)?;
     let signatures_size = signatures.len() as u32;
     if (signatures_size % sigsize) != 0 {
@@ -620,12 +621,12 @@ fn scrubber(output: &Path, version: &str, gpu: &str, sigsize: u32) -> Result<(),
     }
 
     // Extract the patch location
-    let array = format!("ksec2BinArchiveSecurescrubUcode_{gpux}_patch_loc_data");
+    let array = format!("ksec2BinArchiveSecurescrubUcode_{gpux}_BINDATA_LABEL_PATCH_LOC_data");
     let patch_loc_data = get_bytes(&filename, &array, Some(4))?;
     let patch_loc = LittleEndian::read_u32(&patch_loc_data);
 
     // Extract the patch meta variables
-    let array = format!("ksec2BinArchiveSecurescrubUcode_{gpux}_patch_meta_data");
+    let array = format!("ksec2BinArchiveSecurescrubUcode_{gpux}_BINDATA_LABEL_PATCH_META_data");
     let patch_meta_data = get_bytes(&filename, &array, Some(12))?;
 
     let (fuse_ver, engine_id, ucode_id) = patch_meta_data
@@ -686,7 +687,7 @@ fn scrubber(output: &Path, version: &str, gpu: &str, sigsize: u32) -> Result<(),
         .map_err(|err| format!("Could not write to {}: {err}", filename.display()))?;
 
     // Extract the descriptor (nvkm_gsp_booter_fw_hdr)
-    let array = format!("ksec2BinArchiveSecurescrubUcode_{gpux}_header_prod_data");
+    let array = format!("ksec2BinArchiveSecurescrubUcode_{gpux}_BINDATA_LABEL_HEADER_PROD_data");
     let descriptor = get_bytes(&filename, &array, Some(36))?;
 
     // Fifth, the descriptor


### PR DESCRIPTION
Fixed the currently broken `extract-firmware-nouveau` utilities, both Python and Rust versions.