### PR TITLE
Allow custom values for KERNEL_MODLIB

### DIFF
--- a/kernel-open/Makefile
+++ b/kernel-open/Makefile
@@ -27,7 +27,7 @@ else
     KERNEL_SOURCES := $(SYSSRC)
   else
     KERNEL_UNAME ?= $(shell uname -r)
-    KERNEL_MODLIB := /lib/modules/$(KERNEL_UNAME)
+    KERNEL_MODLIB ?= /lib/modules/$(KERNEL_UNAME)
     KERNEL_SOURCES := $(shell ((test -d $(KERNEL_MODLIB)/source && echo $(KERNEL_MODLIB)/source) || (test -d $(KERNEL_MODLIB)/build/source && echo $(KERNEL_MODLIB)/build/source)) || echo $(KERNEL_MODLIB)/build)
   endif
 
@@ -41,7 +41,7 @@ else
     endif
   else
     KERNEL_UNAME ?= $(shell uname -r)
-    KERNEL_MODLIB := /lib/modules/$(KERNEL_UNAME)
+    KERNEL_MODLIB ?= /lib/modules/$(KERNEL_UNAME)
     # $(filter patter...,text) - Returns all whitespace-separated words in text that
     # do match any of the pattern words, removing any words that do not match.
     # Set the KERNEL_OUTPUT only if either $(KERNEL_MODLIB)/source or


### PR DESCRIPTION
Currently, as far as I know - there's no way to modify this variable to force make script to look for custom directory where linux kernel was built. Right now, nvidia drivers are hardcoded to look at `/lib/modules/<kernel_uname>`, and doesn't have option for tinkerers like me to point to custom kernel builds.

A valid reason from my side would be that I am currently building kernel without root permissions. and so I can't install it in `/lib` folder, but use a temporary folder to currently compile nvidia driver too.