### PR TITLE
mapping_reuse: correct range size when unmapping failed allocations

### DIFF
--- a/src/nvidia/src/libraries/mapping_reuse/mapping_reuse.c
+++ b/src/nvidia/src/libraries/mapping_reuse/mapping_reuse.c
@@ -316,7 +316,7 @@ err_unmap:
     {
         void *pCur = token.pList;
         pReuseMappingDb->pUnmapCb(pReuseMappingDb->pGlobalCtx, pAllocCtx,
-            mrangeMake(token.pList->newMappingNode.virtualOffset, range.size));
+            mrangeMake(token.pList->newMappingNode.virtualOffset, token.pList->size));
         token.pList = token.pList->newMappingNode.pNextEntry;
         PORT_FREE(pReuseMappingDb->pAllocator, pCur);
     }


### PR DESCRIPTION
Fixes incorrect unmap range size in the error cleanup path of reusemappingdbMap().

Previously, range.size was used instead of the actual mapped fragment size (token.pList->size) when calling pUnmapCb.   This could result in over-unmapping and overlapping VA ranges, causing inconsistencies and VA allocation failures.
