### PR TITLE
NULL pointer deref of partially uninitialized `uvm_parent_gpu_t` in error path

### DIFF
--- a/kernel-open/nvidia-uvm/uvm_pmm_gpu.c
+++ b/kernel-open/nvidia-uvm/uvm_pmm_gpu.c
@@ -3477,11 +3477,12 @@ void uvm_pmm_gpu_device_p2p_init(uvm_parent_gpu_t *parent_gpu)
 
 void uvm_pmm_gpu_device_p2p_deinit(uvm_parent_gpu_t *parent_gpu)
 {
-    unsigned long pci_start_pfn = pci_resource_start(parent_gpu->pci_dev,
-                                                     uvm_device_p2p_static_bar(parent_gpu)) >> PAGE_SHIFT;
+    unsigned long pci_start_pfn;
     struct page *p2p_page;
 
     if (parent_gpu->device_p2p_initialised && !uvm_parent_gpu_is_coherent(parent_gpu)) {
+        pci_start_pfn = pci_resource_start(parent_gpu->pci_dev,
+                                           uvm_device_p2p_static_bar(parent_gpu)) >> PAGE_SHIFT;
         p2p_page = pfn_to_page(pci_start_pfn);
         devm_memunmap_pages(&parent_gpu->pci_dev->dev, page_pgmap(p2p_page));
     }


### PR DESCRIPTION
Relevant Tickets:
* NVIDIA ID: 5610224
* CoreWeave ID: 789

We first hit this in the 570 releases and it seems like it hasn't been fixed in the 580 ones either.

Control flow that triggers the issue:
```
uvm_ioctl
  -> uvm_api_register_gpu
    -> uvm_va_space_register_gpu
      -> uvm_gpu_retain_by_uuid
        -> gpu_retain_by_uuid_locked
          -> add_gpu
            -> alloc_parent_gpu
              ** allocated parent_gpu but didn't initialize parent_gpu->pci_dev yet **
            <- alloc_parent_gpu
            ...
            -> init_parent_gpu
              ** returns error before initializing parent_gpu->pci_dev **
            <- ini_parent_gpu
            -> remove_gpu
              ...
              -> deinit_gpu
                ...
                -> uvm_pmm_gpu_device_p2p_deinit
                  -> uvm_device_p2p_static_bar
                    ** dereferences gpu->parent->pci_dev and crashes the system **
```