### PR TITLE
nvidia-drm: Fix display not waking after suspend/resume

### DIFF
--- a/kernel-open/nvidia-drm/nvidia-drm-drv.c
+++ b/kernel-open/nvidia-drm/nvidia-drm-drv.c
@@ -2172,6 +2172,11 @@ void nv_drm_suspend_resume(NvBool suspend)
 
     /*
      * NVKMS shuts down all heads on suspend. Update DRM state accordingly.
+     *
+     * BUGFIX: Previously, drm_mode_config_reset() was called on suspend
+     * but nothing restored the display modes on resume, causing black screen
+     * after suspend/resume. Now we properly restore the mode config on resume.
+     * See: https://github.com/NVIDIA/open-gpu-kernel-modules/issues/450
      */
     for (nv_dev = dev_list; nv_dev; nv_dev = nv_dev->next) {
         struct drm_device *dev = nv_dev->dev;
@@ -2191,6 +2196,8 @@ void nv_drm_suspend_resume(NvBool suspend)
             drm_fb_helper_set_suspend_unlocked(dev->fb_helper, 0);
 #endif
             drm_kms_helper_poll_enable(dev);
+            /* Restore mode config to re-enable display output after resume */
+            drm_mode_config_reset(dev);
         }
     }
 


### PR DESCRIPTION
Fixes display wake failure after system suspend/resume by restoring the display mode configuration on resume. Previously, drm_mode_config_reset() was called on suspend to clear display state, but no corresponding restore operation was performed on resume, leaving displays in a black screen state even though the system had successfully resumed.

This creates an asymmetry where:
- Suspend path: calls drm_mode_config_reset() to clear display config
- Resume path: did nothing, assuming VT switch would restore modes

When running X11/Wayland with a modeset owner, the NVKMS layer skips console restore (assuming the DRM client will handle it), but the DRM layer wasn't restoring modes (assuming VT switch would handle it). The result was that neither layer restored the display.

The fix adds drm_mode_config_reset() on the resume path to reinitialize the display outputs, matching the suspend behavior and ensuring displays are properly restored.

Tested on Ubuntu 24.04 with RTX 3090/3080, kernel 6.8.0-90-generic.

Fixes: https://github.com/NVIDIA/open-gpu-kernel-modules/issues/450