### PR TITLE
Fix bashism in conftest.sh

### DIFF
--- a/kernel-open/conftest.sh
+++ b/kernel-open/conftest.sh
@@ -5281,7 +5281,7 @@ case "$5" in
 
         if [ -n "$VGX_BUILD" ]; then
             if [ -f /proc/xen/capabilities ]; then
-                if [ "`cat /proc/xen/capabilities`" == "control_d" ]; then
+                if [ "`cat /proc/xen/capabilities`" = "control_d" ]; then
                     exit 0
                 fi
             else


### PR DESCRIPTION
The script uses == for string comparison, which is a bashism. This causes failure on systems where /bin/sh is a strictly POSIX shell such as Dash. This fixes the syntax to use the standard = operator.