### PR TITLE
Fix use-after-free races in memory pool shrinker and DRM fence destruction

### DIFF
--- a/kernel-open/nvidia-drm/nvidia-drm-fence.c
+++ b/kernel-open/nvidia-drm/nvidia-drm-fence.c
@@ -41,6 +41,8 @@
 struct nv_drm_fence_context;
 
 struct nv_drm_fence_context_ops {
+    /* Called before drm_gem_object_release() to stop callbacks and signal fences */
+    void (*prepare_destroy)(struct nv_drm_fence_context *nv_fence_context);
     void (*destroy)(struct nv_drm_fence_context *nv_fence_context);
 };
 
@@ -205,7 +207,12 @@ to_nv_prime_fence_context(struct nv_drm_fence_context *nv_fence_context) {
     return container_of(nv_fence_context, struct nv_drm_prime_fence_context, base);
 }
 
-static void __nv_drm_prime_fence_context_destroy(
+/*
+ * Prepare for destruction - stop callbacks and signal fences.
+ * This must be called BEFORE drm_gem_object_release() to prevent
+ * race conditions with kernel shrinker/drm_exec infrastructure.
+ */
+static void __nv_drm_prime_fence_context_prepare_destroy(
     struct nv_drm_fence_context *nv_fence_context)
 {
     struct nv_drm_device *nv_dev = nv_fence_context->nv_dev;
@@ -224,6 +231,18 @@ static void __nv_drm_prime_fence_context_destroy(
     nv_drm_gem_prime_force_fence_signal(nv_prime_fence_context);
 
     spin_unlock(&nv_prime_fence_context->lock);
+}
+
+/*
+ * Final destruction - free NVKMS resources and the structure itself.
+ * Called after drm_gem_object_release() has completed.
+ */
+static void __nv_drm_prime_fence_context_destroy(
+    struct nv_drm_fence_context *nv_fence_context)
+{
+    struct nv_drm_device *nv_dev = nv_fence_context->nv_dev;
+    struct nv_drm_prime_fence_context *nv_prime_fence_context =
+        to_nv_prime_fence_context(nv_fence_context);
 
     /* Free nvkms resources */
 
@@ -238,6 +257,7 @@ static void __nv_drm_prime_fence_context_destroy(
 }
 
 static struct nv_drm_fence_context_ops nv_drm_prime_fence_context_ops = {
+    .prepare_destroy = __nv_drm_prime_fence_context_prepare_destroy,
     .destroy = __nv_drm_prime_fence_context_destroy,
 };
 
@@ -402,6 +422,21 @@ static inline struct nv_drm_fence_context *to_nv_fence_context(
 }
 
 /*
+ * Prepare fence context for release - stop callbacks and signal fences.
+ * Called BEFORE drm_gem_object_release() to prevent race with kernel
+ * shrinker/drm_exec.
+ */
+static void
+__nv_drm_fence_context_gem_prepare_release(struct nv_drm_gem_object *nv_gem)
+{
+    struct nv_drm_fence_context *nv_fence_context = to_nv_fence_context(nv_gem);
+
+    if (nv_fence_context->ops->prepare_destroy) {
+        nv_fence_context->ops->prepare_destroy(nv_fence_context);
+    }
+}
+
+/*
  * Tear down of the 'struct nv_drm_fence_context' object is not expected
  * to be happen from any worker thread, if that happen it causes dead-lock
  * because tear down sequence calls to flush all existing
@@ -416,6 +451,7 @@ __nv_drm_fence_context_gem_free(struct nv_drm_gem_object *nv_gem)
 }
 
 const struct nv_drm_gem_object_funcs nv_fence_context_gem_ops = {
+    .prepare_release = __nv_drm_fence_context_gem_prepare_release,
     .free = __nv_drm_fence_context_gem_free,
 };
 
@@ -1112,7 +1148,12 @@ __nv_drm_semsurf_ctx_reg_callbacks(struct nv_drm_semsurf_fence_ctx *ctx)
     }
 }
 
-static void __nv_drm_semsurf_fence_ctx_destroy(
+/*
+ * Prepare for destruction - stop callbacks, timers, and signal fences.
+ * This must be called BEFORE drm_gem_object_release() to prevent
+ * race conditions with kernel shrinker/drm_exec infrastructure.
+ */
+static void __nv_drm_semsurf_fence_ctx_prepare_destroy(
     struct nv_drm_fence_context *nv_fence_context)
 {
     struct nv_drm_device *nv_dev = nv_fence_context->nv_dev;
@@ -1154,22 +1195,17 @@ static void __nv_drm_semsurf_fence_ctx_destroy(
                                                   pendingNvKmsCallback);
     }
 
-    nvKms->freeSemaphoreSurface(nv_dev->pDevice, ctx->pSemSurface);
-
     /*
-     * Now that the semaphore surface, the timer, and the workthread are gone:
-     *
-     * -No more RM/NVKMS callbacks will arrive, nor are any in progress. Freeing
-     *  the semaphore surface cancels all its callbacks associated with this
-     *  instance of it, and idles any pending callbacks.
+     * Now that the timer and the workthread are gone:
      *
      * -No more timer callbacks will arrive, nor are any in flight.
      *
      * -The workthread has been idled and is no longer running.
      *
-     * Further, given the destructor is running, no other references to the
-     * fence context exist, so this code can assume no concurrent access to the
-     * fence context's data will happen from here on out.
+     * Clean up local callback data and force-signal all pending fences.
+     * This must happen BEFORE drm_gem_object_release() so the kernel's
+     * drm_exec/shrinker infrastructure doesn't try to access our dma_resv
+     * while we still have active fences.
      */
 
     if (ctx->callback.local) {
@@ -1179,6 +1215,20 @@ static void __nv_drm_semsurf_fence_ctx_destroy(
     }
 
     __nv_drm_semsurf_force_complete_pending(ctx);
+}
+
+/*
+ * Final destruction - free NVKMS resources and the structure itself.
+ * Called after drm_gem_object_release() has completed.
+ */
+static void __nv_drm_semsurf_fence_ctx_destroy(
+    struct nv_drm_fence_context *nv_fence_context)
+{
+    struct nv_drm_device *nv_dev = nv_fence_context->nv_dev;
+    struct nv_drm_semsurf_fence_ctx *ctx =
+        to_semsurf_fence_ctx(nv_fence_context);
+
+    nvKms->freeSemaphoreSurface(nv_dev->pDevice, ctx->pSemSurface);
 
     nv_drm_free(nv_fence_context);
 }
@@ -1218,6 +1268,7 @@ __nv_drm_semsurf_ctx_timeout_callback(nv_drm_timer *timer)
 
 static struct nv_drm_fence_context_ops
 nv_drm_semsurf_fence_ctx_ops = {
+    .prepare_destroy = __nv_drm_semsurf_fence_ctx_prepare_destroy,
     .destroy = __nv_drm_semsurf_fence_ctx_destroy,
 };
 

--- a/kernel-open/nvidia-drm/nvidia-drm-gem.c
+++ b/kernel-open/nvidia-drm/nvidia-drm-gem.c
@@ -48,7 +48,17 @@ void nv_drm_gem_free(struct drm_gem_object *gem)
 {
     struct nv_drm_gem_object *nv_gem = to_nv_gem_object(gem);
 
-    /* Cleanup core gem object */
+    /*
+     * Prepare for release - stop callbacks and signal fences BEFORE
+     * releasing the core gem object. This prevents race conditions where
+     * the kernel's drm_exec/shrinker infrastructure can access the object
+     * via dma_resv while it's being destroyed.
+     */
+    if (nv_gem->ops->prepare_release) {
+        nv_gem->ops->prepare_release(nv_gem);
+    }
+
+    /* Cleanup core gem object - now safe since fences are detached */
     drm_gem_object_release(&nv_gem->base);
 
 #if !defined(NV_DRM_GEM_OBJECT_HAS_RESV)

--- a/kernel-open/nvidia-drm/nvidia-drm-gem.h
+++ b/kernel-open/nvidia-drm/nvidia-drm-gem.h
@@ -45,6 +45,8 @@
 struct nv_drm_gem_object;
 
 struct nv_drm_gem_object_funcs {
+    /* Called before drm_gem_object_release() to stop callbacks and signal fences */
+    void (*prepare_release)(struct nv_drm_gem_object *nv_gem);
     void (*free)(struct nv_drm_gem_object *nv_gem);
     struct sg_table *(*prime_get_sg_table)(struct nv_drm_gem_object *nv_gem);
     void *(*prime_vmap)(struct nv_drm_gem_object *nv_gem);

--- a/kernel-open/nvidia/nv-vm.c
+++ b/kernel-open/nvidia/nv-vm.c
@@ -409,6 +409,8 @@ typedef struct nv_page_pool_t
 
 nv_page_pool_t *sysmem_page_pools[MAX_NUMNODES][NV_MAX_PAGE_ORDER + 1];
 
+#include <linux/rcupdate.h>
+
 #ifdef NV_SHRINKER_ALLOC_PRESENT
 static nv_page_pool_t *nv_mem_pool_get_from_shrinker(struct shrinker *shrinker)
 {
@@ -420,6 +422,13 @@ static void nv_mem_pool_shrinker_free(nv_page_pool_t *mem_pool)
     if (mem_pool->shrinker != NULL)
     {
         shrinker_free(mem_pool->shrinker);
+        mem_pool->shrinker = NULL;
+
+        /*
+         * Ensure RCU grace period completes before continuing destruction.
+         * This prevents use-after-free if kswapd is iterating shrinkers.
+         */
+        synchronize_rcu();
     }
 }
 
@@ -445,6 +454,13 @@ static void nv_mem_pool_shrinker_free(nv_page_pool_t *mem_pool)
     if (mem_pool->shrinker != NULL)
     {
         unregister_shrinker(mem_pool->shrinker);
+        mem_pool->shrinker = NULL;
+
+        /*
+         * Ensure RCU grace period completes before continuing destruction.
+         * This prevents use-after-free if kswapd is iterating shrinkers.
+         */
+        synchronize_rcu();
     }
 }
 
@@ -692,6 +708,9 @@ nv_mem_pool_destroy(nv_page_pool_t *mem_pool)
 {
     NV_STATUS status;
 
+    // Unregister shrinker FIRST to prevent callbacks during cleanup
+    nv_mem_pool_shrinker_free(mem_pool);
+
     status = os_acquire_mutex(mem_pool->lock);
     WARN_ON(status != NV_OK);
     nv_mem_pool_free_page_list(&mem_pool->dirty_list, mem_pool->order);
@@ -705,8 +724,6 @@ nv_mem_pool_destroy(nv_page_pool_t *mem_pool)
     // free clean pages after scrubber can't add any new
     nv_mem_pool_free_page_list(&mem_pool->clean_list, mem_pool->order);
     os_release_mutex(mem_pool->lock);
-
-    nv_mem_pool_shrinker_free(mem_pool);
 
     os_free_mutex(mem_pool->lock);
 
@@ -759,6 +776,7 @@ nv_page_pool_t* nv_mem_pool_init(int node_id, unsigned int order)
      nv_mem_pool_shrinker_register(mem_pool, shrinker);
 
      mem_pool->shrinker = shrinker;
+
      return mem_pool;
 
 failed:


### PR DESCRIPTION
# Fix use-after-free races in memory pool shrinker and DRM fence destruction

## Summary

This patch fixes two related use-after-free race conditions that cause kernel crashes under memory pressure:

1. **Memory pool shrinker race**: `kswapd` can invoke shrinker callbacks while `nv_mem_pool_destroy()` is freeing pool resources
2. **DRM fence/GEM destruction race**: Kernel drm_exec/shrinker infrastructure can access `dma_resv` while fence contexts are being destroyed

Both issues stem from the same root cause: cleanup callbacks not being stopped before the resources they access are released.

---

## Issue 1: Memory Pool Shrinker Race

### Problem

The shrinker is unregistered **after** freeing the pool's page lists:

```c
void nv_mem_pool_destroy(nv_page_pool_t *mem_pool)
{
    // Free dirty pages, stop scrubber, free clean pages
    // SHRINKER STILL REGISTERED - CALLBACKS CAN FIRE!

    nv_mem_pool_shrinker_free(mem_pool);  // Too late
}
```

### Race Scenario

```
nv_mem_pool_destroy()                kswapd
─────────────────────                ──────
Free dirty_list
                                     shrink_slab() calls shrinker callback
                                     Callback accesses freed lists
                                     USE-AFTER-FREE
shrinker_free()
```

### Fix

1. Move `nv_mem_pool_shrinker_free()` to the **start** of destruction
2. Add `synchronize_rcu()` after unregistration to ensure no callbacks are in-flight (kernel iterates shrinkers under RCU)
3. NULL the shrinker pointer immediately after unregistration

---

## Issue 2: DRM Fence Context Destruction Race

### Problem

When a GEM object with an associated fence context is destroyed, the current code:
1. Calls `drm_gem_object_release()` (releases dma_resv)
2. Then stops callbacks and signals fences

This allows the kernel's drm_exec/shrinker infrastructure to access `dma_resv` while fences are still active.

### Race Scenario

```
nv_drm_gem_free()                    Kernel drm_exec/shrinker
─────────────────                    ────────────────────────
drm_gem_object_release()
  → dma_resv released
                                     Iterates dma_resv for eviction
                                     Accesses fence context
                                     USE-AFTER-FREE
Stop callbacks, signal fences
Free fence context
```

### Fix

Introduce two-phase destruction for fence contexts:

1. **`prepare_release`/`prepare_destroy`**: Stop callbacks, timers, and signal all pending fences *before* `drm_gem_object_release()`
2. **`free`/`destroy`**: Release NVKMS resources and free memory *after* the GEM object is fully released

This ensures fences are detached from `dma_resv` before the kernel can no longer safely access them.

---

## Changes

### nv-vm.c
- Move shrinker unregistration to start of `nv_mem_pool_destroy()`
- Add `synchronize_rcu()` after `shrinker_free()`/`unregister_shrinker()`
- NULL shrinker pointer after unregistration

### nvidia-drm-gem.h/c
- Add `prepare_release` callback to `nv_drm_gem_object_funcs`
- Call `prepare_release` before `drm_gem_object_release()` in `nv_drm_gem_free()`

### nvidia-drm-fence.c
- Add `prepare_destroy` callback to `nv_drm_fence_context_ops`
- Split `__nv_drm_prime_fence_context_destroy()` into prepare/destroy phases
- Split `__nv_drm_semsurf_fence_ctx_destroy()` into prepare/destroy phases
- Implement `__nv_drm_fence_context_gem_prepare_release()` to call prepare phase

---

## Testing

- **Hardware**: NVIDIA RTX 5090 (Blackwell architecture)
- **Driver**: nvidia-open 590.48.01
- **Kernel**: 6.18.5 (Arch Linux)
- **Before patch**: Random system freezes every few hours to days, crashes in `kswapd` path through nvidia shrinker/fence callbacks
- **After patch**: Stable under sustained memory pressure and GPU workloads

---

## Impact

These bugs affect all users of nvidia-open kernel modules under memory pressure. Symptoms include:

- Random system freezes requiring hard reboot
- Kernel panic in `shrink_slab()` or `drm_exec` paths
- Page fault at nvidia module addresses during memory reclaim

The fixes follow established kernel conventions: unregister/stop callbacks before freeing the resources they access.

---

## References

- Linux kernel shrinker API: `include/linux/shrinker.h`
- DRM GEM object lifecycle: `drivers/gpu/drm/drm_gem.c`
- Affected files:
  - `kernel-open/nvidia/nv-vm.c`
  - `kernel-open/nvidia-drm/nvidia-drm-gem.c`
  - `kernel-open/nvidia-drm/nvidia-drm-gem.h`
  - `kernel-open/nvidia-drm/nvidia-drm-fence.c`