### PR TITLE
fix: Fix jiffies wrap in os_get_monotonic_time_ns() causing hangs after 66 days

### DIFF
--- a/kernel-open/nvidia/os-interface.c
+++ b/kernel-open/nvidia/os-interface.c
@@ -701,15 +701,9 @@ NvU64 NV_API_CALL os_get_monotonic_time_ns_hr(void)
 
 NvU64 NV_API_CALL os_get_monotonic_time_ns(void)
 {
-#if defined(NV_JIFFIES_TO_TIMESPEC_PRESENT)
-    struct timespec ts;
-    jiffies_to_timespec(jiffies, &ts);
-    return (NvU64) timespec_to_ns(&ts);
-#else
     struct timespec64 ts;
-    jiffies_to_timespec64(jiffies, &ts);
+    ktime_get_raw_ts64(&ts);
     return (NvU64) timespec64_to_ns(&ts);
-#endif
 }
 
 NvU64 NV_API_CALL os_get_monotonic_tick_resolution_ns(void)


### PR DESCRIPTION
Fix for `nvidia-smi` hanging after approximately 66 days of uptime.

  The function `os_get_monotonic_time_ns()` in [`kernel-open/nvidia/os-interface.c`](kernel-open/nvidia/os-interface.c) uses `jiffies_to_timespec64(jiffies, &ts)` to obtain
  monotonic time. The `jiffies` counter is an unsigned 32-bit value that wraps at 2^32 ticks. At `HZ=750` this occurs after `2^32 / 750 / 86400 = 66.3 days`. When the wrap
  occurs, `jiffies_to_timespec64()` returns a near-zero value, causing time to appear to jump backwards.

  This breaks timeout comparisons throughout the driver. Code in [`thread_state.c`](src/nvidia/src/kernel/core/thread_state.c), [`locks.c`](src/nvidia/src/kernel/core/locks.c),
  and [`gpu_timeout.c`](src/nvidia/src/kernel/gpu/gpu_timeout.c) stores a start time and later checks if `currentTime >= startTime + timeout`. After the wrap, `currentTime` is
  suddenly much smaller than `startTime`, so these comparisons behave incorrectly and all operations appear to have timed out immediately.

  The fix replaces the jiffies-based implementation with `ktime_get_raw_ts64()`, which reads from hardware timers and provides a monotonic 64-bit nanosecond timestamp that won't
   wrap for centuries. This matches the implementation already used by `os_get_monotonic_time_ns_hr()` in the same file.