### PR TITLE
nvidia-peermem: Prefer ofa_kernel-dkms path for DOCA-OFED headers

### DIFF
--- a/kernel-open/nvidia-peermem/nvidia-peermem.Kbuild
+++ b/kernel-open/nvidia-peermem/nvidia-peermem.Kbuild
@@ -43,17 +43,11 @@ else
     OFA_ARCH := $(ARCH)
 endif
 OFA_DIR := /usr/src/ofa_kernel
-OFA_CANDIDATES = $(OFA_DIR)/$(OFA_ARCH)/$(KERNELRELEASE) $(OFA_DIR)/$(KERNELRELEASE) $(OFA_DIR)/default /var/lib/dkms/mlnx-ofed-kernel
-MLNX_OFED_KERNEL := $(shell for d in $(OFA_CANDIDATES); do \
-                              if [ -d "$$d" ]; then \
-                                echo "$$d"; \
-                                exit 0; \
-                              fi; \
-                            done; \
-                            echo $(OFA_DIR) \
-                     )
+OFA_DKMS_DIR := $(OFA_DIR)-dkms
+OFA_CANDIDATES = $(OFA_DKMS_DIR)/$(OFA_ARCH)/$(KERNELRELEASE) $(OFA_DIR)/$(OFA_ARCH)/$(KERNELRELEASE) $(OFA_DIR)/$(KERNELRELEASE) $(OFA_DIR)/default
+MLNX_OFED_KERNEL := $(firstword $(wildcard $(OFA_CANDIDATES)))
 
-ifneq ($(shell test -d $(MLNX_OFED_KERNEL) && echo "true" || echo "" ),)
+ifneq ($(MLNX_OFED_KERNEL),)
     NVIDIA_PEERMEM_CFLAGS += -I$(MLNX_OFED_KERNEL)/include -I$(MLNX_OFED_KERNEL)/include/rdma
     KBUILD_EXTRA_SYMBOLS := $(MLNX_OFED_KERNEL)/Module.symvers
 endif


### PR DESCRIPTION
New DKMS-based DOCA-OFED installations store headers in `/usr/src/ofa_kernel-dkms/` and create symlinks from `/usr/src/ofa_kernel/` for backward compatibility.

Using the `...-dkms` path directly is more robust as it contains the actual files, avoiding potential issues with symlinks that may be missing, broken, or not yet created during package installation.