### PR TITLE
displayport: skip unnecessary DSC for MST modes within link bandwidth

### DIFF
--- a/src/common/displayport/src/dp_connectorimpl.cpp
+++ b/src/common/displayport/src/dp_connectorimpl.cpp
@@ -1422,22 +1422,91 @@ bool ConnectorImpl::compoundQueryAttachMST(Group * target,
             {
                 //
                 // The uncompressed mode fits within available local link PBN.
-                // Try the full generic validation (watermark, per-device
-                // bandwidth at intermediate MST branches). If it succeeds,
-                // DSC is unnecessary.
+                // Speculatively try the full generic validation (watermark,
+                // per-device bandwidth at intermediate MST branches). If it
+                // succeeds, DSC is unnecessary.
                 //
+                // compoundQueryAttachMSTGeneric mutates connector and
+                // per-device state (compoundQueryResult, compoundQueryLocalLinkPBN,
+                // and device compound_query_state). Since this is a speculative
+                // check, save the state before and restore it on failure so the
+                // DSC path starts from a clean slate.
+                //
+                bool savedCompoundQueryResult = compoundQueryResult;
+
+                //
+                // Save per-device compound_query_state for all devices in this
+                // group's MST path. On failure, intermediate branch devices may
+                // retain stale timeslot allocations from the uncompressed attempt
+                // which would cause the DSC path to either skip them (via
+                // bandwidthAllocatedForIndex) or over-count their timeslots.
+                //
+                struct {
+                    DeviceImpl *dev;
+                    unsigned timeslots_used_by_query;
+                    unsigned bandwidthAllocatedForIndex;
+                } savedDevState[63];
+                unsigned savedDevCount = 0;
+                bool savedDevOverflow = false;
+
+                for (Device * d = target->enumDevices(0);
+                     d && !savedDevOverflow;
+                     d = target->enumDevices(d))
+                {
+                    DeviceImpl * tail = (DeviceImpl *)d;
+                    while (tail && tail->getParent())
+                    {
+                        if (savedDevCount >= 63)
+                        {
+                            savedDevOverflow = true;
+                            break;
+                        }
+                        savedDevState[savedDevCount].dev = tail;
+                        savedDevState[savedDevCount].timeslots_used_by_query =
+                            tail->bandwidth.compound_query_state.timeslots_used_by_query;
+                        savedDevState[savedDevCount].bandwidthAllocatedForIndex =
+                            tail->bandwidth.compound_query_state.bandwidthAllocatedForIndex;
+                        savedDevCount++;
+                        tail = (DeviceImpl*)tail->getParent();
+                    }
+                }
+
+                //
+                // If we couldn't save all device state (extremely deep MST
+                // topology), skip the speculative pre-check to avoid partial
+                // state restoration on failure.
+                //
+                if (savedDevOverflow)
+                    goto skipPreCheck;
+
                 if (compoundQueryAttachMSTGeneric(target, modesetParams,
                                                   &localInfo, pDscParams,
                                                   pErrorCode))
                 {
                     return true;
                 }
+
                 //
-                // Generic validation failed — possibly due to insufficient
-                // bandwidth at an intermediate MST branch link. DSC can
-                // reduce PBN enough to fit through the bottleneck, so fall
-                // through to the DSC path below.
+                // Generic validation failed — restore all state so the DSC
+                // path runs on a clean slate.
                 //
+                // compoundQueryLocalLinkPBN is already rolled back by
+                // compoundQueryAttachMSTGeneric on failure.
+                //
+                compoundQueryResult = savedCompoundQueryResult;
+                for (unsigned idx = 0; idx < savedDevCount; idx++)
+                {
+                    savedDevState[idx].dev->bandwidth.compound_query_state
+                        .timeslots_used_by_query =
+                            savedDevState[idx].timeslots_used_by_query;
+                    savedDevState[idx].dev->bandwidth.compound_query_state
+                        .bandwidthAllocatedForIndex =
+                            savedDevState[idx].bandwidthAllocatedForIndex;
+                }
+
+                if (pErrorCode)
+                    *pErrorCode = DP_IMP_ERROR_NONE;
+            skipPreCheck:
             }
         }
 


### PR DESCRIPTION
## Summary

Add a PBN pre-check in `compoundQueryAttachMST()` to skip unnecessary DSC compression when the link has sufficient bandwidth for the uncompressed mode.

## Problem

The MST mode validation path unconditionally tries DSC when the device supports it, even when the link has sufficient bandwidth. This causes instability through MST hubs and USB-C docks that don't handle DSC negotiation well, manifesting as:
- Spurious HPD short pulses
- DPCD AUX channel failures
- Intermittent display disconnection ("input signal out of range")

The SST path (`compoundQueryAttachSST`) already handles this correctly by checking `willLinkSupportModeSST()` before enabling DSC.

## Solution

Before entering the DSC path, calculate the PBN required for the uncompressed mode and check if it fits within available local link PBN. If it does, skip DSC and proceed directly to `compoundQueryAttachMSTGeneric()` for full validation.

This mirrors the SST behavior without introducing state management issues (the PBN pre-check is side-effect-free).

## Behavior Preserved

- **Forced DSC** (`DSC_FORCE_ENABLE`): Still enabled
- **DSC_DUAL mode**: Still enabled  
- **Bandwidth-insufficient modes**: DSC still used as fallback
- Only truly unnecessary DSC (bandwidth sufficient, not forced) is skipped

## Testing

Tested on:
- NVIDIA RTX PRO 4000 Blackwell Generation Laptop GPU
- Lenovo ThinkPad USB-C Dock Gen 2 (40AS) — DP 1.4 MST hub
- LEN S27q-10 2560x1440@60Hz monitor
- Driver 590.48.01 (open kernel modules)

Before: Monitor intermittently disconnects every few seconds with DSC enabled at 10 bpp
After: Stable connection without DSC (mode fits in DP 1.4 HBR3 uncompressed)

## Related Issues

Fixes #1024

May help with:
- #879 - Second external display missing via USB-C hub
- #960 - DisplayPort monitor limited resolution through dock
- #816 - Blackwell DP2.1 issues
- #511 - Screen flickering regression
