### PR TITLE
displayport: use correct buffer size in setOuiSource

### DIFF
--- a/src/common/displayport/src/dp_configcaps.cpp
+++ b/src/common/displayport/src/dp_configcaps.cpp
@@ -666,7 +666,7 @@ AuxRetry::status DPCDHALImpl::setOuiSource
     NvU8 chipRevision
 )
 {
-    NvU8 ouiBuffer[16];
+    NvU8 ouiBuffer[10] = {0};
 
     //  The first 3 bytes are IEEE_OUI. 2 hex digits per register.
     ouiBuffer[0] = (ouiId >> 16) & 0xFF;
@@ -690,9 +690,6 @@ AuxRetry::status DPCDHALImpl::setOuiSource
             model++;
     }
     ouiBuffer[9] = chipRevision;
-
-    for (int i = 0xA; i<=0xF; ++i)
-        ouiBuffer[i] = 0;
 
     return bus.write(NV_DPCD_SOURCE_IEEE_OUI, &ouiBuffer[0], sizeof ouiBuffer);
 }


### PR DESCRIPTION
Don't send more bytes than necessary to avoid problems with displays that only accept the exact amount of bytes defined in the DisplayPort standard.

Currently, 16 bytes are allocated and sent, although only addresses from 300h to 309h are valid. The remaining bytes are zeroed, but that still seems to cause problems on some displays that won't accept the additional bytes. Therefore, reduce the buffer size to the required amount and only send the relevant bytes.

This resolves the problem for me on TUXEDO InfinityBook Max and TUXEDO Stellaris devices with 5050 and 5060 GPUs. I have no evidence that this caused any actual problems with the driver, but doing things correctly and avoiding warnings in the console is always good.