### PR TITLE
fifo: forward NV2080_CTRL_CMD_FIFO_CONFIG_CTXSW_TIMEOUT to GSP for physical GPUs

### DIFF
--- a/src/nvidia/src/kernel/gpu/fifo/kernel_fifo_ctrl.c
+++ b/src/nvidia/src/kernel/gpu/fifo/kernel_fifo_ctrl.c
@@ -598,6 +598,43 @@ subdeviceCtrlCmdFifoUpdateChannelInfo_IMPL
     return status;
 }
 
+/*!
+ * @brief subdeviceCtrlCmdFifoConfigCtxswTimeout
+ *
+ * Forward engine context-switch timeout configuration to GSP physical RM.
+ * Without this, NV2080_CTRL_CMD_FIFO_CONFIG_CTXSW_TIMEOUT always returns
+ * NV_ERR_NOT_SUPPORTED for physical GPUs, preventing runtimes from extending
+ * the default ~4 s timeout on compute-heavy workloads (Xid 109).
+ *
+ * Lock Requirements:
+ *      Assert that API lock and GPUs lock held on entry
+ */
+NV_STATUS
+subdeviceCtrlCmdFifoConfigCtxswTimeout_IMPL
+(
+    Subdevice *pSubdevice,
+    NV2080_CTRL_FIFO_CONFIG_CTXSW_TIMEOUT_PARAMS *pParams
+)
+{
+    CALL_CONTEXT *pCallContext  = resservGetTlsCallContext();
+    RmCtrlParams *pRmCtrlParams = pCallContext->pControlParams;
+    OBJGPU       *pGpu          = GPU_RES_GET_GPU(pSubdevice);
+    RM_API       *pRmApi        = GPU_GET_PHYSICAL_RMAPI(pGpu);
+
+    NV_ASSERT_OR_RETURN(pRmCtrlParams->bDeferredApi || rmGpuLockIsOwner(),
+        NV_ERR_INVALID_LOCK_STATE);
+
+    if (!IS_GSP_CLIENT(pGpu))
+        return NV_ERR_NOT_SUPPORTED;
+
+    return pRmApi->Control(pRmApi,
+                           pRmCtrlParams->hClient,
+                           pRmCtrlParams->hObject,
+                           pRmCtrlParams->cmd,
+                           pRmCtrlParams->pParams,
+                           pRmCtrlParams->paramsSize);
+}
+
 NV_STATUS
 diagapiCtrlCmdFifoGetChannelState_IMPL
 (


### PR DESCRIPTION
  ## Problem

  On physical (non-VF) GPUs `NV2080_CTRL_CMD_FIFO_CONFIG_CTXSW_TIMEOUT`
  (0x20801110) always returns `NV_ERR_NOT_SUPPORTED`.  The HAL table wires
  non-VF GPUs to the `_5baef9` stub which unconditionally returns the error
  without forwarding to firmware.

  This prevents the D3D/Vulkan runtime from extending the engine
  context-switch timeout beyond the GSP default, causing
  **Xid 109 (CTX SWITCH TIMEOUT)** on compute-heavy workloads.  Reproduced
  on Blackwell (RTX 50xx), driver 590.48.01, with DX12 games under Proton.

  ## Root cause

  ```c
  /* g_subdevice_nvoc.c — before */
  pThis->__subdeviceCtrlCmdFifoConfigCtxswTimeout__ =
      &subdeviceCtrlCmdFifoConfigCtxswTimeout_5baef9; /* NV_ERR_NOT_SUPPORTED */

  Unlike the neighbouring subdeviceCtrlCmdFifoUpdateChannelInfo (which
  correctly routes non-VF GPUs through _IMPL → GSP), no _IMPL existed
  for the ctxsw-timeout control.

  Fix

  Add subdeviceCtrlCmdFifoConfigCtxswTimeout_IMPL in kernel_fifo_ctrl.c
  that forwards the call to GSP physical RM via GPU_GET_PHYSICAL_RMAPI,
  following the same pattern as subdeviceCtrlCmdFifoUpdateChannelInfo_IMPL.
  Wire the non-VF HAL entry to _IMPL instead of the stub (requires NVOC
  regeneration of g_subdevice_nvoc.h / g_subdevice_nvoc.c).

  Risk

  If firmware does not support this RPC it returns NV_ERR_NOT_SUPPORTED
  through the forwarding path — identical behaviour to the stub, no
  regression possible.

  Testing

  Verified on RTX 5060 Ti, kernel 6.17, driver 590.48.01:
  - Before: control call returned NV_ERR_NOT_SUPPORTED, Xid 109 appeared during heavy DX12 compute
  - After: Xid 109 absent across multiple runs of the same workload
