### PR TITLE
*/nvkms-kapi.h: Exclude struct NvKmsKapiCallbacks from RANDSTRUCT

### DIFF
--- a/kernel-open/common/inc/nvkms-kapi.h
+++ b/kernel-open/common/inc/nvkms-kapi.h
@@ -604,7 +604,7 @@ struct NvKmsKapiCallbacks {
     void (*remove)(NvU32 gpuId);
     void (*probe)(const struct NvKmsKapiGpuInfo *gpu_info);
 /* https://github.com/NVIDIA/open-gpu-kernel-modules/issues/1033 */
-#if defined(CONFIG_RANDSTRUCT_PERFORMANCE) || defined(CONFIG_RANDSTRUCT_FULL)
+#if defined(CONFIG_RANDSTRUCT_PERFORMANCE) || defined(CONFIG_RANDSTRUCT_FULL) || defined(CONFIG_GCC_PLUGIN_RANDSTRUCT)
 } __attribute__((no_randomize_layout));
 #else
 };

--- a/src/nvidia-modeset/kapi/interface/nvkms-kapi.h
+++ b/src/nvidia-modeset/kapi/interface/nvkms-kapi.h
@@ -604,7 +604,7 @@ struct NvKmsKapiCallbacks {
     void (*remove)(NvU32 gpuId);
     void (*probe)(const struct NvKmsKapiGpuInfo *gpu_info);
 /* https://github.com/NVIDIA/open-gpu-kernel-modules/issues/1033 */
-#if defined(CONFIG_RANDSTRUCT_PERFORMANCE) || defined(CONFIG_RANDSTRUCT_FULL)
+#if defined(CONFIG_RANDSTRUCT_PERFORMANCE) || defined(CONFIG_RANDSTRUCT_FULL) || defined(CONFIG_GCC_PLUGIN_RANDSTRUCT)
 } __attribute__((no_randomize_layout));
 #else
 };


### PR DESCRIPTION
#1033

When the RANDSTRUCT plugin (`CONFIG_RANDSTRUCT*`) is applied, the physical layout of `struct NvKmsKapiCallbacks` in `nvidia-drm.ko` and `nvidia-modeset.ko` may become different at compile-time, leading to a freeze or kernel panic at shutdown. Disable randomization for that struct.