### PR TITLE
nvidia-modeset: fix UB in DP DSC flatnessDetThresh calculation

### DIFF
--- a/src/nvidia-modeset/include/nvkms-utils.h
+++ b/src/nvidia-modeset/include/nvkms-utils.h
@@ -167,6 +167,9 @@ static inline NvU64 nvCtxDmaOffsetFromBytes(NvU64 ctxDmaOffset)
 
 NvU8 nvPixelDepthToBitsPerComponent(enum nvKmsPixelDepth pixelDepth);
 
+NvU32 nvDscPpsGetBitsPerComponent(const NvU32 *pps);
+NvU32 nvDscComputeFlatnessDetThresh(NvU32 bpc);
+
 typedef enum {
     EVO_LOG_WARN,
     EVO_LOG_ERROR,

--- a/src/nvidia-modeset/src/nvkms-evo3.c
+++ b/src/nvidia-modeset/src/nvkms-evo3.c
@@ -7153,11 +7153,7 @@ static void EvoSetHdmiDscParams(const NVDispEvoRec *pDispEvo,
              pDscInfo->type == NV_DSC_INFO_EVO_TYPE_HDMI);
 
     bpc = nvPixelDepthToBitsPerComponent(pixelDepth);
-    if (bpc < 8) {
-        nvAssert(bpc >= 8);
-        bpc = 8;
-    }
-    flatnessDetThresh = (2 << (bpc - 8));
+    flatnessDetThresh = nvDscComputeFlatnessDetThresh(bpc);
 
     nvDmaSetStartEvoMethod(pChannel, NVC67D_HEAD_SET_DSC_CONTROL(head), 1);
     nvDmaSetEvoMethodData(pChannel,
@@ -7206,15 +7202,20 @@ static void EvoSetDpDscParams(const NVDispEvoRec *pDispEvo,
                               const NVDscInfoEvoRec *pDscInfo)
 {
     NVEvoChannelPtr pChannel = pDispEvo->pDevEvo->core;
-    NvU32 flatnessDetThresh;
+    NvU32 bpc, flatnessDetThresh;
     NvU32 i;
 
     nvAssert(pDscInfo->type == NV_DSC_INFO_EVO_TYPE_DP);
 
-    // XXX: I'm pretty sure that this is wrong.
-    // BitsPerPixelx16 is something like (24 * 16) = 384, and 2 << (384 - 8) is
-    // an insanely large number.
-    flatnessDetThresh = (2 << (pDscInfo->dp.bitsPerPixelX16 - 8)); /* ??? */
+    /*
+     * Extract bits_per_component from the PPS that was already computed
+     * by the DP library.  The DP path does not receive a pixelDepth
+     * parameter (unlike HDMI), so we read bpc from PPS byte 3 bits [7:4].
+     *
+     * Per VESA DSC 1.2a: flatness_det_thresh = 2 << (bpc - 8).
+     */
+    bpc = nvDscPpsGetBitsPerComponent(pDscInfo->dp.pps);
+    flatnessDetThresh = nvDscComputeFlatnessDetThresh(bpc);
 
     nvAssert((pDscInfo->dp.dscMode == NV_DSC_EVO_MODE_DUAL) ||
                 (pDscInfo->dp.dscMode == NV_DSC_EVO_MODE_SINGLE));

--- a/src/nvidia-modeset/src/nvkms-evo4.c
+++ b/src/nvidia-modeset/src/nvkms-evo4.c
@@ -1358,11 +1358,7 @@ static void EvoSetHdmiDscParamsC9(const NVDispEvoRec *pDispEvo,
              pDscInfo->type == NV_DSC_INFO_EVO_TYPE_HDMI);
 
     bpc = nvPixelDepthToBitsPerComponent(pixelDepth);
-    if (bpc < 8) {
-        nvAssert(bpc >= 8);
-        bpc = 8;
-    }
-    flatnessDetThresh = (2 << (bpc - 8));
+    flatnessDetThresh = nvDscComputeFlatnessDetThresh(bpc);
 
     nvDmaSetStartEvoMethod(pChannel, NVC97D_HEAD_SET_DSC_CONTROL(head), 1);
     nvDmaSetEvoMethodData(pChannel,
@@ -1408,15 +1404,20 @@ static void EvoSetDpDscParamsC9(const NVDispEvoRec *pDispEvo,
                               const NVDscInfoEvoRec *pDscInfo)
 {
     NVEvoChannelPtr pChannel = pDispEvo->pDevEvo->core;
-    NvU32 flatnessDetThresh;
+    NvU32 bpc, flatnessDetThresh;
     NvU32 i;
 
     nvAssert(pDscInfo->type == NV_DSC_INFO_EVO_TYPE_DP);
 
-    // XXX: I'm pretty sure that this is wrong.
-    // BitsPerPixelx16 is something like (24 * 16) = 384, and 2 << (384 - 8) is
-    // an insanely large number.
-    flatnessDetThresh = (2 << (pDscInfo->dp.bitsPerPixelX16 - 8)); /* ??? */
+    /*
+     * Extract bits_per_component from the PPS that was already computed
+     * by the DP library.  The DP path does not receive a pixelDepth
+     * parameter (unlike HDMI), so we read bpc from PPS byte 3 bits [7:4].
+     *
+     * Per VESA DSC 1.2a: flatness_det_thresh = 2 << (bpc - 8).
+     */
+    bpc = nvDscPpsGetBitsPerComponent(pDscInfo->dp.pps);
+    flatnessDetThresh = nvDscComputeFlatnessDetThresh(bpc);
 
     nvAssert((pDscInfo->dp.dscMode == NV_DSC_EVO_MODE_DUAL) ||
                 (pDscInfo->dp.dscMode == NV_DSC_EVO_MODE_SINGLE));

--- a/src/nvidia-modeset/src/nvkms-utils.c
+++ b/src/nvidia-modeset/src/nvkms-utils.c
@@ -508,6 +508,52 @@ NvU8 nvPixelDepthToBitsPerComponent(enum nvKmsPixelDepth pixelDepth)
     return 0;
 }
 
+/*
+ * Extract bits_per_component from a DSC Picture Parameter Set (PPS).
+ *
+ * The PPS is an array of NvU32 dwords stored in native byte order.
+ * Per VESA DSC 1.2a Table 4-1, byte 3 bits [7:4] hold the
+ * bits_per_component value (8, 10, or 12 for typical displays).
+ * On little-endian machines byte 3 maps to pps[0] bits [31:28].
+ *
+ * Returns the raw bpc value from the PPS, or 0 if the field is
+ * reserved/zero.
+ */
+NvU32 nvDscPpsGetBitsPerComponent(const NvU32 *pps)
+{
+    /*
+     * PPS DWord 0 layout (bytes stored in native byte order):
+     *
+     *   bits [31:28] : bits_per_component   (PPS byte 3, bits [7:4])
+     *   bits [27:24] : linebuf_depth        (PPS byte 3, bits [3:0])
+     *   bits [23:16] : reserved             (PPS byte 2)
+     *   bits [15:8]  : pps_identifier       (PPS byte 1)
+     *   bits [7:4]   : dsc_version_major    (PPS byte 0, bits [7:4])
+     *   bits [3:0]   : dsc_version_minor    (PPS byte 0, bits [3:0])
+     */
+    return (pps[0] >> 28) & 0xF;
+}
+
+/*
+ * Compute the DSC flatness detection threshold from bits_per_component.
+ *
+ * Per VESA DSC 1.2a section 4.1:
+ *   flatness_det_thresh = 2 << (bpc - 8)
+ *
+ * bpc is expected to be >= 8 (the minimum the DSC standard supports).
+ * If bpc is unexpectedly below 8, the function clamps to the minimum
+ * valid threshold of 2 and fires an assertion.
+ */
+NvU32 nvDscComputeFlatnessDetThresh(NvU32 bpc)
+{
+    if (bpc < 8) {
+        nvAssert(bpc >= 8);
+        bpc = 8;
+    }
+
+    return (2 << (bpc - 8));
+}
+
 /* Import function required by nvBuildModeName() */
 
 int nvBuildModeNameSnprintf(char *str, size_t size, const char *format, ...)


### PR DESCRIPTION
## Problem

`EvoSetDpDscParams()` (nvkms-evo3.c) and `EvoSetDpDscParamsC9()` (nvkms-evo4.c) compute the DSC flatness detection threshold as:

```c
flatnessDetThresh = (2 << (pDscInfo->dp.bitsPerPixelX16 - 8));
```

`bitsPerPixelX16` is the target bits-per-pixel multiplied by 16 (e.g. 128 for 8.0 bpp, 384 for 24.0 bpp). This produces a left shift of 120–376 bits, which is **undefined behavior** in C — the shift amount far exceeds the width of `NvU32`. The hardware register field `FLATNESS_DET_THRESH` is only 10 bits wide, so whatever garbage value results from the UB gets truncated and programmed into the DSC encoder.

The existing code even has an engineer comment acknowledging this:
```c
// XXX: I'm pretty sure that this is wrong.
// BitsPerPixelx16 is something like (24 * 16) = 384, and 2 << (384 - 8) is
// an insanely large number.
```

The HDMI DSC path (`EvoSetHdmiDscParams` / `EvoSetHdmiDscParamsC9`) handles this correctly by deriving `bpc` from the `pixelDepth` parameter and computing `2 << (bpc - 8)`. However, the DP path does not receive a `pixelDepth` parameter.

## Fix

Per VESA DSC 1.2a section 4.1, the correct formula is:
```
flatness_det_thresh = 2 << (bits_per_component - 8)
```

Since the DP path doesn't have `pixelDepth`, we extract `bits_per_component` directly from PPS byte 3 bits [7:4], which the DP library has already computed when generating the PPS.

This patch introduces two shared utility functions:
- **`nvDscPpsGetBitsPerComponent()`** — extracts bpc from PPS DWord 0 bits [31:28]
- **`nvDscComputeFlatnessDetThresh()`** — computes `2 << (bpc - 8)` with validation/clamping for safety

Both the DP and HDMI paths now use `nvDscComputeFlatnessDetThresh()`, consolidating the duplicated inline validation that previously existed only in the HDMI path.

## Impact

Affects all DisplayPort DSC displays on all GPU generations supported by the open kernel modules. The flatness detection threshold controls how the DSC encoder identifies flat (uniform) image regions for optimized bit allocation. An incorrect threshold may cause suboptimal compression and potential visual artifacts.

## Files Changed

- `src/nvidia-modeset/include/nvkms-utils.h` — declare new helpers
- `src/nvidia-modeset/src/nvkms-utils.c` — implement `nvDscPpsGetBitsPerComponent()` and `nvDscComputeFlatnessDetThresh()`
- `src/nvidia-modeset/src/nvkms-evo3.c` — fix `EvoSetDpDscParams()`, refactor `EvoSetHdmiDscParams()`
- `src/nvidia-modeset/src/nvkms-evo4.c` — fix `EvoSetDpDscParamsC9()`, refactor `EvoSetHdmiDscParamsC9()`

Closes #1029