### PR TITLE
Fix operator precedence and integer width in nv_dma_buf_mmap

### DIFF
--- a/kernel-open/nvidia/nv-dmabuf.c
+++ b/kernel-open/nvidia/nv-dmabuf.c
@@ -1230,7 +1230,7 @@ nv_dma_buf_mmap(
     NvU32 i = 0;
     nv_dma_buf_file_private_t *priv = buf->priv;
     unsigned long addr = vma->vm_start;
-    NvU32 total_skip_size = 0;
+    NvU64 total_skip_size = 0;
     NvU64 total_map_len  = NV_VMA_SIZE(vma);
     NvU64 off_in_range_array = 0;
     NvU32 index;
@@ -1341,7 +1341,7 @@ found_start_page:
     nv_vm_flags_set(vma, VM_SHARED | VM_DONTEXPAND | VM_DONTDUMP);
 
     // Create user mapping
-    for (; i < (priv->num_objects && (addr < vma->vm_end)); i++)
+    for (; (i < priv->num_objects) && (addr < vma->vm_end); i++)
     {
         NvU32 range_count = priv->handles[i].memArea.numRanges;
 


### PR DESCRIPTION
## Summary

Fix two bugs in `nv_dma_buf_mmap()` (`kernel-open/nvidia/nv-dmabuf.c`):

### 1. Operator precedence error (line 1344)

The outer for-loop condition:
```c
for (; i < (priv->num_objects && (addr < vma->vm_end)); i++)
```
evaluates `&&` first, producing a boolean `0` or `1`. The loop runs at most **once** (`i < 1`), regardless of `num_objects`.

For multi-object DMA-buf exports, only the first object's ranges are mapped. The function returns success despite the incomplete mapping. Accessing the unmapped portion of the VMA causes SIGBUS.

**Fix:**
```c
for (; (i < priv->num_objects) && (addr < vma->vm_end); i++)
```

### 2. Integer truncation in `total_skip_size` (line 1233)

`total_skip_size` is `NvU32` but accumulates `NvU64` range sizes. For DMA-bufs larger than 4 GB the offset wraps, causing incorrect range lookups in the page-mapping loop.

**Fix:** widen from `NvU32` to `NvU64`.

## Verification

Operator precedence bug confirmed with standalone C reproduction:

```
num_objects  buggy_iters     correct_iters   match?
----------  -----------     -------------   ------
1            1               1               OK
5            1               5               BUG!
100          1               100             BUG!
```

Integer truncation confirmed:
```
range[0]=0x100000000  NvU32=0x00000000  NvU64=0x0000000100000000  OVERFLOW!
```

## Test plan

- [x] Verify multi-object DMA-buf export + mmap maps all objects correctly
- [x] Verify DMA-buf exports with total size > 4 GB compute correct offsets
- [x] Verify single-object DMA-buf mmap behavior is unchanged