### PR TITLE
nvidia-drm: set link-status to Bad when force-enabled HDMI sink disappears

### DIFF
--- a/kernel-open/nvidia-drm/nvidia-drm-connector.c
+++ b/kernel-open/nvidia-drm/nvidia-drm-connector.c
@@ -100,6 +100,30 @@ __nv_drm_detect_encoder(struct NvKmsKapiDynamicDisplayParams *pDetectParams,
             break;
     }
 
+    /*
+     * For force-enabled connectors, probe the real physical state first
+     * (without forcing) so we can set link-status to Bad when the sink
+     * disappears. This lets userspace compositors trigger a modeset for
+     * link re-training when the sink returns (e.g. a TV switching back
+     * from built-in apps to its HDMI input).
+     */
+    if (pDetectParams->forceConnected) {
+        struct NvKmsKapiDynamicDisplayParams physicalProbe;
+
+        memset(&physicalProbe, 0, sizeof(physicalProbe));
+        physicalProbe.handle = nv_encoder->hDisplay;
+
+        if (nvKms->getDynamicDisplayInfo(nv_dev->pDevice, &physicalProbe)) {
+            if (!physicalProbe.connected) {
+                drm_connector_set_link_status_property(
+                    connector, DRM_MODE_LINK_STATUS_BAD);
+            } else {
+                drm_connector_set_link_status_property(
+                    connector, DRM_MODE_LINK_STATUS_GOOD);
+            }
+        }
+    }
+
 #if defined(NV_DRM_CONNECTOR_HAS_OVERRIDE_EDID)
     if (connector->override_edid) {
 #else


### PR DESCRIPTION
## Summary

When a connector has `DRM_FORCE_ON` (via `video=CONNECTOR:e`), the detect callback passes `forceConnected=NV_TRUE` to NvKMS, which always returns `connected=true`. The DRM `link-status` property is never updated when the physical HDMI sink disappears (e.g. a TV switching to built-in apps like Netflix).

Per the DRM/KMS specification, drivers must set `link-status` to `DRM_MODE_LINK_STATUS_BAD` when the link degrades, so userspace compositors can trigger a modeset for link re-training. KWin already handles `linkStatus == Bad` with `m_forceModeset = true` ([drm_gpu.cpp:332-335](https://invent.kde.org/plasma/kwin/-/blob/master/src/backends/drm/drm_gpu.cpp#L332)), but this path never fires because the driver never sets the property.

## Fix

Add a physical state probe (without `forceConnected`) before the forced detect in `__nv_drm_detect_encoder()`. When the real physical state is disconnected but the connector is force-enabled, set `link-status` to `Bad`. When the sink is physically present, restore it to `Good`.

This is a minimal, self-contained change (24 lines added) in `kernel-open/nvidia-drm/nvidia-drm-connector.c` that enables existing compositor recovery paths without any userspace changes.

## Test setup

- GPU: NVIDIA GeForce RTX 5070 Ti
- Display: Samsung 75" 4K TV via HDMI-A-1 (force-enabled with `video=HDMI-A-1:e`)
- Driver: nvidia-open 595.58.03
- Kernel: 6.19.10 (CachyOS)
- Compositor: KWin 6.6.3 (Wayland)

## Reproduction

1. Connect TV via HDMI, add `video=HDMI-A-1:e` to kernel cmdline
2. Boot, verify TV displays correctly
3. Switch TV to built-in app (Netflix)
4. Switch TV back to HDMI input
5. Display remains blank because link-status stays "Good" and compositor never modesets

## Related

- Issue: #1084
- KWin MR (closed, redirected here per maintainer): https://invent.kde.org/plasma/kwin/-/merge_requests/9034
- Kernel DRM patch (complementary): https://lore.kernel.org/dri-devel/20260328152550.20222-1-miguelsedek@gmail.com/
- Similar issue class: #1055