### PR TITLE
fix(uvm): check pRmApi->Control status in nvGpuOpsSetPageDirectory

### DIFF
--- a/src/nvidia/src/kernel/rmapi/nv_gpu_ops.c
+++ b/src/nvidia/src/kernel/rmapi/nv_gpu_ops.c
@@ -8984,6 +8984,16 @@ NV_STATUS nvGpuOpsSetPageDirectory(struct gpuAddressSpace *vaSpace,
                              NV0080_CTRL_CMD_DMA_SET_PAGE_DIRECTORY,
                              &params,
                              sizeof(params));
+    if (status != NV_OK)
+    {
+        if (vaspaceIsExternallyOwned(pVAS))
+        {
+            nvGpuOpsEnableVaSpaceChannels(vaSpace);
+        }
+        _nvGpuOpsLocksRelease(&acquiredLocks);
+        threadStateFree(&threadState, THREAD_STATE_FLAGS_NONE);
+        return status;
+    }
 
     //
     // Store page table root DMA Address (GPU Physical Address) for RM client


### PR DESCRIPTION
nvGpuOpsSetPageDirectory unconditionally dereferences the return value of vaspaceGetPageDirBase() after calling pRmApi->Control() for NV0080_CTRL_CMD_DMA_SET_PAGE_DIRECTORY without checking the status. If the control call fails (e.g. due to GSP RPC resource exhaustion), the error cleanup path in deviceCtrlCmdDmaSetPageDirectory_IMPL calls gvaspaceExternalRootDirRevoke which sets pExternalPDB to NULL. The subsequent vaspaceGetPageDirBase() then returns NULL, and the call to memdescGetPhysAddr() triggers a kernel NULL pointer dereference.

Add the missing status check after pRmApi->Control() and bail out with proper cleanup (re-enabling channels if externally owned, releasing locks, and freeing thread state) on failure.