### PR TITLE
nvidia: make Resizable BAR resize failure non-fatal, and skip proactively on Thunderbolt

### DIFF
--- a/kernel-open/conftest.sh
+++ b/kernel-open/conftest.sh
@@ -4067,6 +4067,23 @@ compile_test() {
             compile_check_conftest "$CODE" "NV_PCI_REBAR_GET_POSSIBLE_SIZES_PRESENT" "" "functions"
         ;;
 
+        pci_is_thunderbolt_attached)
+            #
+            # Determine if the pci_is_thunderbolt_attached() function is
+            # present.
+            #
+            # Added by commit 0d4ef7ce7e78 ("PCI: Identify Thunderbolt
+            # devices") in v4.15.
+            #
+            CODE="
+            #include <linux/pci.h>
+            void conftest_pci_is_thunderbolt_attached(void) {
+                pci_is_thunderbolt_attached();
+            }"
+
+            compile_check_conftest "$CODE" "NV_PCI_IS_THUNDERBOLT_ATTACHED_PRESENT" "" "functions"
+        ;;
+
         pci_resize_resource_has_exclude_bars_arg)
             #
             # Determine if pci_resize_resource() has exclude_bars argument.

--- a/kernel-open/nvidia/nv-pci.c
+++ b/kernel-open/nvidia/nv-pci.c
@@ -1949,9 +1949,18 @@ nv_pci_probe
         goto err_zero_dev;
 
     if (nv_resize_pcie_bars(pci_dev)) {
-        nv_printf(NV_DBG_ERRORS,
-            "NVRM: Fatal Error while attempting to resize PCIe BARs.\n");
-        goto err_zero_dev;
+        /*
+         * Resizable BAR is an enhancement, not a requirement.  When
+         * the resize fails (commonly because the upstream bridge
+         * prefetchable window is too small to accommodate a GiB-scale
+         * BAR, as seen with Thunderbolt/USB4 hotplug bridges), the
+         * device is still functional with its existing BAR
+         * allocation.  Do not turn a minor performance degradation
+         * into a hard probe failure -- log a warning and continue.
+         */
+        nv_printf(NV_DBG_WARNINGS,
+            "NVRM: PCIe BAR resize failed; continuing with the existing "
+            "BAR allocation.\n");
     }
 
     nvl->all_mappings_revoked = NV_TRUE;

--- a/kernel-open/nvidia/nv-pci.c
+++ b/kernel-open/nvidia/nv-pci.c
@@ -208,6 +208,25 @@ static int nv_resize_pcie_bars(struct pci_dev *pci_dev) {
         return 0;
     }
 
+#if defined(NV_PCI_IS_THUNDERBOLT_ATTACHED_PRESENT)
+    /*
+     * Thunderbolt / USB4 hotplug bridges have a small prefetchable MMIO
+     * window that cannot accommodate a GiB-scale resized BAR.  Skip
+     * the resize attempt proactively rather than trying and failing,
+     * which avoids an uninformative -ENOENT in the kernel log and
+     * sidesteps the failure path entirely.
+     */
+    if (pci_is_thunderbolt_attached(pci_dev))
+    {
+        nv_printf(NV_DBG_INFO,
+                  "NVRM: %04x:%02x:%02x.%x: device is downstream of Thunderbolt, "
+                  "skipping BAR1 resize\n",
+                  NV_PCI_DOMAIN_NUMBER(pci_dev), NV_PCI_BUS_NUMBER(pci_dev),
+                  NV_PCI_SLOT_NUMBER(pci_dev), PCI_FUNC(pci_dev->devfn));
+        return 0;
+    }
+#endif
+
     // Check if BAR1 has PCIe rebar capabilities
     sizes = pci_rebar_get_possible_sizes(pci_dev, NV_GPU_BAR1);
     if (sizes == 0) {

--- a/kernel-open/nvidia/nvidia.Kbuild
+++ b/kernel-open/nvidia/nvidia.Kbuild
@@ -120,6 +120,7 @@ NV_CONFTEST_FUNCTION_COMPILE_TESTS += pde_data
 NV_CONFTEST_FUNCTION_COMPILE_TESTS += xen_ioemu_inject_msi
 NV_CONFTEST_FUNCTION_COMPILE_TESTS += phys_to_dma
 NV_CONFTEST_FUNCTION_COMPILE_TESTS += pci_rebar_get_possible_sizes
+NV_CONFTEST_FUNCTION_COMPILE_TESTS += pci_is_thunderbolt_attached
 NV_CONFTEST_FUNCTION_COMPILE_TESTS += get_backlight_device_by_name
 NV_CONFTEST_FUNCTION_COMPILE_TESTS += dma_direct_map_resource
 NV_CONFTEST_FUNCTION_COMPILE_TESTS += flush_cache_all


### PR DESCRIPTION
# nvidia: make Resizable BAR resize failure non-fatal, and skip proactively on Thunderbolt

## Problem

`nv_resize_pcie_bars()` is invoked during `nv_pci_probe()` as an
optimization: it tries to grow BAR1 to the largest size the hardware
advertises so the CPU can address the full VRAM directly.  When the
resize fails, the driver currently treats this as a fatal probe error
and bails out via `err_zero_dev`, **preventing the GPU from binding at
all**.

This is the code path in question (kernel-open/nvidia/nv-pci.c,
595.58.03 line numbers):

```c
if (nv_resize_pcie_bars(pci_dev)) {
    nv_printf(NV_DBG_ERRORS,
        "NVRM: Fatal Error while attempting to resize PCIe BARs.\n");
    goto err_zero_dev;
}
```

The "fatal error" framing is too strong.  Resizable BAR is an optional
enhancement to the PCI 3.0 spec, not a correctness requirement.  A GPU
with a non-resized BAR1 is still fully functional for CUDA, graphics,
and everything else the driver supports -- it just uses the DMA path
instead of direct CPU-mapped access to the full VRAM.

## Motivating case: Thunderbolt 5 eGPU enclosures

This limitation is particularly visible with Thunderbolt / USB4 eGPU
enclosures, which have become much more common with products like the
Gigabyte Aorus RTX 5090 AI Box, Razer Core X, Sonnet Breakaway Box,
OneXGPU, etc.  TB/USB4 hotplug PCIe bridges have a prefetchable MMIO
window on the order of hundreds of MiB, which cannot accommodate the
GiB-scale BAR1 that modern NVIDIA GPUs advertise.
`pci_resize_resource()` returns `-ENOENT`, `nv_resize_pcie_bars()`
returns non-zero, the existing code path fails, and the eGPU silently
never appears in `nvidia-smi`.

A reproduction:

- Host: ASUS ProArt Z890-CREATOR WIFI, Core Ultra 9 285K
- Enclosure: Gigabyte Aorus RTX 5090 AI Box (GV-N5090IXEB-32GD) over
  Thunderbolt 5 (Intel JHL9580 "Barlow Ridge" host controller on
  motherboard, JHL9480 hub in enclosure)
- OS: Fedora 43, kernel 7.0.0-rc7
- Driver: open-gpu-kernel-modules 595.58.03 (DKMS), unmodified
- Kernel cmdline: `pci=assign-busses,hpbussize=0x10,hpmmiosize=64M,hpmmioprefsize=384M,realloc pcie_port_pm=off pcie_aspm.policy=performance intel_iommu=off thunderbolt.clx=0`
  (The kernel cmdline sets the hotplug bridge prefetchable window to
  384 MiB, which fits BAR1 at the default 256 MiB size but cannot fit
  a 32 GiB resized BAR1.)

Observed without this PR:

```
[   ...] nvidia 0000:8b:00.0: enabling device (0000 -> 0002)
[   ...] nvidia 0000:8b:00.0: BAR 14 [mem size 0x100000000 64bit pref]: failed to resize: -2
[   ...] NVRM: Fatal Error while attempting to resize PCIe BARs.
(device never binds)
```

Observed with this PR:

```
[   ...] nvidia 0000:8b:00.0: enabling device (0000 -> 0002)
[   ...] nvidia 0000:8b:00.0: device is downstream of Thunderbolt, skipping BAR1 resize
[   ...] NVRM: loading NVIDIA UNIX Open Kernel Module for x86_64  595.58.03  Release Build
(device binds, nvidia-smi shows the eGPU alongside the internal GPU,
CUDA workloads run normally)
```

Beyond eGPUs, the same non-fatal semantics help in other constrained
topologies:

- Hypervisor guests with a passed-through GPU and a constrained MMIO
  window from the host.
- Older chipsets with small prefetchable windows that haven't been
  tuned for ReBAR.
- Platforms where firmware has locked resources and
  `host->preserve_config` is set but the existing guard didn't cover
  every failure path.

## Fix (two commits)

**Commit 1: "nvidia: make Resizable BAR resize failure non-fatal"**

This is the correctness fix.  Replace the `goto err_zero_dev` with a
warning print and continue probe.  The device will bind with whatever
BAR size was allocated at PCI enumeration time.  This commit alone
fixes the reported symptom.

**Commit 2: "nvidia: skip Resizable BAR for Thunderbolt-attached devices"**

This is a complementary optimization on top of commit 1.  Detect
Thunderbolt attachment via `pci_is_thunderbolt_attached()` (in
`<linux/pci.h>` since Linux v4.15 / 2017) and skip the resize attempt
proactively, rather than attempting it and falling through to the
warning from commit 1.  This saves some probe time and keeps the
kernel log free of the uninformative `-ENOENT` from
`pci_resize_resource()`.

The helper is gated behind a new conftest
(`NV_PCI_IS_THUNDERBOLT_ATTACHED_PRESENT`) in
`kernel-open/conftest.sh` and declared in `kernel-open/nvidia/nvidia.Kbuild`,
so older kernels without the helper still build cleanly and fall back
to the generic commit-1 behavior.  Non-Thunderbolt devices are
unaffected -- `pci_is_thunderbolt_attached()` returns false for a GPU
on a native PCIe slot, so normal ReBAR continues to run.

## Compatibility and review notes

- **Either commit stands alone**: commit 1 alone fixes the bug.
  Commit 2 can be dropped if reviewers prefer a minimal change.  But
  the two together are tidier because commit 2 keeps the kernel log
  clean on what is now the most common failure case (TB eGPUs).
- **No new module parameters, no new registry keys.** This is a pure
  behavioral fix; nothing to document in `nv-reg.h`.
- **Non-TB GPUs unchanged.** The commit 2 fast-path predicate is
  topology-based and only matches GPUs behind TB bridges.
- **Preserves existing diagnostic behavior** for the old "really
  fatal" path: `nv_pci_validate_bars()` still bails out hard on
  BAR0 checks elsewhere in `nv_pci_probe()`, and `err_zero_dev` is
  still used for the failures that are genuinely fatal (e.g.
  `rm_init_private_state()`).  This PR only changes the one specific
  failure mode that had false-positive fatality.
- **Conftest pattern mirrors existing neighbors** (see the
  `pci_rebar_get_possible_sizes` case immediately above the new
  entry).

## Related

- Composes cleanly with PR #984 ("nvidia: add RmForceExternalGpu
  registry key" by @roger-pmta).  #984 teaches the driver to treat a
  specified GPU as external; this PR makes sure the driver can
  actually bind a TB-attached GPU in the first place, which is the
  prerequisite for #984's registry key to do anything useful on a
  TB5 eGPU like the Aorus AI Box.  We've been running both patches
  together in production for a dual-RTX-5090 workstation (internal
  + TB5 eGPU).  They solve different problems and are orthogonal.
- Reference recipe for the full TB5 eGPU enablement is documented at
  https://egpu.io/forums/builds/2023-14-lenovo-thinkpad-x1-carbon-gen-11-13th10cu-rtx-5080-32gbps-tb4-sonnet-breakaway-box-850-t5-linux-rocky-10-1/
  (5080 / Sonnet) and in the companion configuration notes for the
  RTX 5090 + Aorus AI Box setup this PR was developed against.
