### PR TITLE
nvidia-drm: trigger connector detect on hotplug events

### DIFF
--- a/kernel-open/nvidia-drm/nvidia-drm-drv.c
+++ b/kernel-open/nvidia-drm/nvidia-drm-drv.c
@@ -663,7 +663,12 @@ static void nv_drm_handle_hotplug_event(struct work_struct *work)
     struct nv_drm_device *nv_dev =
         container_of(dwork, struct nv_drm_device, hotplug_event_work);
 
-    drm_kms_helper_hotplug_event(nv_dev->dev);
+    /*
+     * Use drm_helper_hpd_irq_event() so connector->detect() is run and
+     * connector status is refreshed; drm_kms_helper_hotplug_event() only
+     * sends a uevent without updating status.
+     */
+    drm_helper_hpd_irq_event(nv_dev->dev);
 }
 
 static int nv_drm_dev_load(struct drm_device *dev)


### PR DESCRIPTION
Note that this fix was developed and validated against a Jetson Orin AGX 64GB running the r36.5 fork of these kernel modules (https://gitlab.com/nvidia/nv-tegra/tegra/kernel-src/nv-kernel-display-driver/-/tree/l4t/l4t-r36.5) where there is no meaningful commit history, so submission there did not seem appropriate.

As such, this change was rebased to upstream here, but could not be revalidated.

Also, if this repository is not the appropriate upstream target, please let me know and I can redirect this patch.

---

When a DisplayPort sink is hotplugged after boot, the connector status reported in /sys/class/drm/card0-DP-1/status remains "disconnected" even though the kernel observes the HPD edge and emits a HOTPLUG=1 uevent. Userspace must run `echo detect > status` to refresh the connector before a modeset succeeds.

The hotplug work handler nv_drm_handle_hotplug_event() was calling drm_kms_helper_hotplug_event(), which only sends a uevent and invokes the output_poll_changed callback. It never calls connector->detect(). Because the connector status is therefore never refreshed, DRM core keeps reporting the cached "disconnected" state.

Call drm_helper_hpd_irq_event() instead. That helper iterates all DRM_CONNECTOR_POLL_HPD-flagged connectors, runs connector->detect() on each, updates the recorded status, and only sends the uevent if the status actually changed. This is the correct entry point for an HPD-edge notification and produces a fresh status read for userspace without requiring a manual detect.
