### PR TITLE
uvm: avoid over-reserving tracker entries

### DIFF
--- a/kernel-open/nvidia-uvm/uvm_tracker.c
+++ b/kernel-open/nvidia-uvm/uvm_tracker.c
@@ -211,7 +211,11 @@ NV_STATUS uvm_tracker_add_tracker(uvm_tracker_t *dst, uvm_tracker_t *src)
     if (uvm_tracker_is_empty(src))
         return NV_OK;
 
-    status = uvm_tracker_reserve(dst, src->size);
+    if (dst->size + src->size > dst->max_size)
+        status = reserve_for_entries_from_tracker(dst, src);
+    else
+        status = NV_OK;
+
     if (status == NV_ERR_NO_MEMORY) {
         uvm_tracker_remove_completed(dst);
         uvm_tracker_remove_completed(src);

--- a/kernel-open/nvidia-uvm/uvm_tracker_test.c
+++ b/kernel-open/nvidia-uvm/uvm_tracker_test.c
@@ -388,6 +388,13 @@ static NV_STATUS test_tracker_add_tracker(uvm_va_space_t *va_space)
     TEST_CHECK_RET(uvm_tracker_get_entries(&dup_tracker)[0].channel == entry.channel);
     TEST_CHECK_RET(uvm_tracker_get_entries(&dup_tracker)[0].value == entry.value);
 
+    status = uvm_tracker_add_tracker(&dup_tracker, &tracker);
+    TEST_CHECK_GOTO(status == NV_OK, done);
+    TEST_CHECK_RET(dup_tracker.size == 1);
+    TEST_CHECK_RET(dup_tracker.max_size == ARRAY_SIZE(dup_tracker.static_entries));
+    TEST_CHECK_RET(uvm_tracker_get_entries(&dup_tracker)[0].channel == entry.channel);
+    TEST_CHECK_RET(uvm_tracker_get_entries(&dup_tracker)[0].value == entry.value);
+
     for_each_va_space_gpu(gpu, va_space) {
         uvm_channel_pool_t *pool;
 


### PR DESCRIPTION
Avoid unnecessary tracker growth when merging duplicate tracker entries.

`uvm_tracker_add_tracker()` used to reserve `src->size` entries before merging. That is only a conservative upper bound: if a source entry already has a matching channel in the destination tracker, `uvm_tracker_add_entry()` updates the existing value instead of appending a new entry.

This can make a small tracker grow from its static entry storage to dynamic storage even when the merge adds no new entries.

Change the reserve path to compute the exact requirement only when the conservative upper bound would exceed the current capacity. The existing OOM fallback remains unchanged.

Also extend `test_tracker_add_tracker()` to cover the duplicate single-entry merge case and verify that the destination tracker remains on static storage.

Build-tested with:

    make modules -j$(nproc)

Result:

    build exit code: 0

I did not install or load the generated modules.
