### PR TITLE
Don't wake a runtime-suspended dGPU to service NVPCF/GPS ACPI notifies

### DIFF
--- a/src/nvidia/arch/nvalloc/unix/src/osapi.c
+++ b/src/nvidia/arch/nvalloc/unix/src/osapi.c
@@ -2023,6 +2023,17 @@ static void RmHandleGPSStatusChange
     RM_API            *pRmApi;
     THREAD_STATE_NODE  threadState;
     NV0000_CTRL_SYSTEM_GPS_CONTROL_PARAMS gpsControl = { 0 };
+    nv_priv_t         *nvp = NV_GET_NV_PRIV(pNv);
+
+    //
+    // Don't wake a runtime-suspended GPU just to handle a GPS status
+    // change; service it only when the GPU is already awake.
+    //
+    if (nvp != NULL &&
+        nvp->dynamic_power.state == NV_DYNAMIC_POWER_STATE_IDLE_INDICATED)
+    {
+        return;
+    }
 
     pRmApi = RmUnixRmApiPrologue(pNv, &threadState, RM_LOCK_MODULES_ACPI);
     if (pRmApi == NULL)
@@ -6066,13 +6077,23 @@ void NV_API_CALL rm_acpi_nvpcf_notify(
         if (pGpu != NULL)
         {
             nv_state_t *nv = NV_GET_NV_STATE(pGpu);
-            if ((rmStatus = os_ref_dynamic_power(nv, NV_DYNAMIC_PM_FINE)) ==
-                                                                         NV_OK)
+            nv_priv_t *nvp = NV_GET_NV_PRIV(nv);
+
+            //
+            // Don't wake a runtime-suspended GPU just to deliver an NVPCF
+            // event; service it only when the GPU is already awake.
+            //
+            if (nvp == NULL ||
+                nvp->dynamic_power.state != NV_DYNAMIC_POWER_STATE_IDLE_INDICATED)
             {
-               gpuNotifySubDeviceEvent(pGpu, NV2080_NOTIFIERS_NVPCF_EVENTS,
-                                       NULL, 0, 0, 0);
+                if ((rmStatus = os_ref_dynamic_power(nv, NV_DYNAMIC_PM_FINE)) ==
+                                                                             NV_OK)
+                {
+                   gpuNotifySubDeviceEvent(pGpu, NV2080_NOTIFIERS_NVPCF_EVENTS,
+                                           NULL, 0, 0, 0);
+                }
+                os_unref_dynamic_power(nv, NV_DYNAMIC_PM_FINE);
             }
-            os_unref_dynamic_power(nv, NV_DYNAMIC_PM_FINE);
         }
         rmapiLockRelease();
     }


### PR DESCRIPTION
On RTD3 laptops the discrete GPU sits in D3cold while idle. On some machines the platform keeps delivering ACPI `Notify()` events (to the NVPCF device, and as GPS status changes) even while the GPU is suspended, for example around battery/AC transitions or when the SBIOS pushes a new thermal or power-limit hint.

The two handlers that service those notifies, `rm_acpi_nvpcf_notify()` and `RmHandleGPSStatusChange()`, both call `os_ref_dynamic_power()` unconditionally. That resumes the GPU purely to deliver an event that does nothing while it's powered down, and it then re-suspends. On a fair number of laptops the next notify lands right away, so the GPU never settles in D3cold. Folks in #860 describe it cycling D0/D3cold every ~11 seconds on battery, and the current workaround is to patch the ACPI tables to strip the `Notify(NPCF, 0xC0)`.

This skips the resume when the GPU is already runtime-suspended (`NV_DYNAMIC_POWER_STATE_IDLE_INDICATED`), the same guard `rm_pmu_perfmon_get_load()` already uses a few functions away. Why it's safe:

* the NVPCF event is only consumed by nvidia-powerd, which has nothing to do while the GPU is asleep
* GPS/SBIOS data is re-read on the next `StateLoad`, so a skipped sync is recovered when the GPU next powers up
* power-source (AC/battery) changes go through a separate path (`rm_power_source_change_event`) and are left untouched

I traced the wake on an RTX 4060 mobile (ASUS TUF, open module):

```text
acpi_ev_notify_dispatch -> rm_acpi_nvpcf_notify -> os_ref_dynamic_power
  -> nv_indicate_not_idle -> ... -> acpi_pci_set_power_state (D3cold -> D0)
```

With the guard in place the handlers still run, but the GPU stays in D3cold. Verified on 595.45.04 and 610.43.02.
