### PR TITLE
build: honor TARGET_ARCH for kernel modules

### DIFF
--- a/kernel-open/Makefile
+++ b/kernel-open/Makefile
@@ -73,7 +73,13 @@ else
   OBJDUMP ?= objdump
 
   ifndef ARCH
-    ARCH := $(shell uname -m | sed -e 's/i.86/i386/' \
+    ifdef TARGET_ARCH
+      ARCH := $(TARGET_ARCH)
+    else
+      ARCH := $(shell uname -m)
+    endif
+
+    ARCH := $(shell echo $(ARCH) | sed -e 's/i.86/i386/' \
       -e 's/aarch64/arm64/' \
       -e 's/riscv64/riscv/' \
     )


### PR DESCRIPTION
## Summary
- Use TARGET_ARCH as the default Kbuild architecture when ARCH is not explicitly set.
- Normalize TARGET_ARCH=aarch64 to Kbuild ARCH=arm64, matching the README cross-build command.
- Keep explicit ARCH=... unchanged for callers that already pass it directly.

Fixes #541.

## Testing
- git diff --check main..fix-target-arch-kbuild
- make -C kernel-open -n modules TARGET_ARCH=aarch64 CC=aarch64-linux-gnu-gcc LD=aarch64-linux-gnu-ld AR=aarch64-linux-gnu-ar CXX=aarch64-linux-gnu-g++ OBJCOPY=aarch64-linux-gnu-objcopy
  - Confirmed the generated Kbuild invocation includes ARCH=arm64. The dry run stops afterward in this macOS workspace because /lib/modules/25.5.0/build is not present.