### PR TITLE
modeset: honor forced FRL rate during link assessment

### DIFF
--- a/kernel-open/nvidia-modeset/nvidia-modeset-linux.c
+++ b/kernel-open/nvidia-modeset/nvidia-modeset-linux.c
@@ -101,7 +101,9 @@ static bool malloc_verbose = false;
 module_param_named(malloc_verbose, malloc_verbose, bool, 0400);
 
 MODULE_PARM_DESC(force_frl_rate,
-                 "Override the default FRL rate selection (2 = max FRL rate w/ DSC, 1 = max FRL rate, 0 = default rate)");
+                 "Override the default FRL rate selection and use EDID-declared "
+                 "FRL link capabilities (2 = max FRL rate w/ DSC, "
+                 "1 = max FRL rate, 0 = default rate)");
 static int force_frl_rate = 0;
 module_param_named(force_frl_rate, force_frl_rate, int, 0400);
 

--- a/src/nvidia-modeset/src/nvkms-hdmi.c
+++ b/src/nvidia-modeset/src/nvkms-hdmi.c
@@ -1978,8 +1978,10 @@ NvBool nvHdmiFrlAssessLink(NVDpyEvoPtr pDpyEvo)
     NVDevEvoPtr pDevEvo = pDispEvo->pDevEvo;
     NVHDMIPKT_RESULT ret;
     const NvU32 displayId = nvDpyIdToNvU32(pDpyEvo->pConnectorEvo->displayId);
+    const enum NvKmsFrlRateForce forceFrlRate = nvkms_force_frl_rate();
     NvBool bIsDisplayActive = NV_FALSE;
-    NvBool bPerformLinkTrainingToAssess = NV_TRUE;
+    NvBool bPerformLinkTrainingToAssess =
+        (forceFrlRate == NVKMS_FRL_RATE_FORCE_NONE);
     HDMI_FRL_DATA_RATE currFRLRate = HDMI_FRL_DATA_RATE_NONE;
 
     nvAssert(nvDpyIsHdmiEvo(pDpyEvo) && nvHdmiDpySupportsFrl(pDpyEvo));
@@ -1991,11 +1993,9 @@ NvBool nvHdmiFrlAssessLink(NVDpyEvoPtr pDpyEvo)
         const HDMI_FRL_CONFIG *pFrlConfig = &pHeadState->hdmiFrlConfig;
 
         bIsDisplayActive = NV_TRUE;
-        if (pFrlConfig->frlRate == HDMI_FRL_DATA_RATE_NONE) {
-            bPerformLinkTrainingToAssess = NV_FALSE;
-        } else {
-            bPerformLinkTrainingToAssess = NV_TRUE;
-        }
+        bPerformLinkTrainingToAssess =
+            (pFrlConfig->frlRate != HDMI_FRL_DATA_RATE_NONE) &&
+            (forceFrlRate == NVKMS_FRL_RATE_FORCE_NONE);
         currFRLRate = pFrlConfig->frlRate;
     }
 


### PR DESCRIPTION
## Summary
- Treat `nvidia-modeset.force_frl_rate` as an explicit opt-in to use EDID-declared FRL capabilities during HDMI FRL link assessment.
- Leave the default physical link-training assessment path unchanged when `force_frl_rate=0`.
- Update the module parameter description so `modinfo` reflects the EDID-capability behavior.

This helps forced/headless HDMI connectors where a valid override EDID advertises FRL (for example Max_FRL_Rate=6) but physical link assessment cannot complete because there is no real sink handshake, causing high-bandwidth modes such as 4K120 to be pruned.

Fixes #1184.

## Testing
- `git diff --check`
- `make -C kernel-open -n modules`
  - Reached the kernel build handoff and then stopped in this macOS workspace because `/lib/modules/25.5.0/build` is not present.
- Reporter validation on #1184 / this PR:
  - Hardware/software: RTX 3060 Ti, `nvidia-open 610.43.02`, kernel `7.0.11`
  - Boot setup: `drm.edid_firmware=HDMI-A-1:edid/<file> video=HDMI-A-1:e`
  - Override EDID advertises `Max_FRL_Rate=6` plus VIC 118
  - Stock driver with `nvidia-modeset.force_frl_rate=1` and `=2` still stayed capped at 4K60
  - With this patch plus `nvidia-modeset.force_frl_rate=1`, `3840x2160@119.88` appears and sets on the force-enabled HDMI connector
  - HDR also enables and Sunshine HEVC Main10 streaming was confirmed end to end
  - Custom high-bandwidth DisplayID timings such as `3024x1890@120` and `2752x2064@120` also validate and set
