### PR TITLE
nvidia: suppress newline-only RM log output

### DIFF
--- a/kernel-open/nvidia/os-interface.c
+++ b/kernel-open/nvidia/os-interface.c
@@ -843,6 +843,12 @@ NvU32 cur_debuglevel = 0xffffffff;
  */
 inline void NV_API_CALL out_string(const char *str)
 {
+    if ((str == NULL) || (str[0] == '\0') ||
+        ((str[0] == '\n') && (str[1] == '\0')))
+    {
+        return;
+    }
+
     printk("%s", str);
 }
 


### PR DESCRIPTION
Fixes #1098.

out_string() forwards strings from RM directly to printk(). If RM emits a separator consisting only of a newline, this can create a blank kernel log record during boot and appear in journalctl -p3 as a false error.

Ignore NULL, empty, and newline-only strings before calling printk(). Real log messages are still printed unchanged.

Although the visible symptom is a log artifact, this changes executable logging behavior by suppressing separator-only output before printk().

Validation:
- git diff --check

Not performed:
- Local module build
- Runtime boot-log test