### PR TITLE
Bound the GPFIFO-space wait in nvWriteGpEntry()

### DIFF
--- a/src/common/unix/nvidia-push/src/nvidia-push.c
+++ b/src/common/unix/nvidia-push/src/nvidia-push.c
@@ -627,6 +627,7 @@ void __nvPushMakeRoom(NvPushChannelPtr push_buffer, NvU32 count)
     NvU32 getOffset;
     NvU32 putOffset;
     NvBool fenceToEnd = FALSE;
+    NvU64 baseTime, currentTime;
 
     putOffset = (NvU32) ((char *)push_buffer->main.buffer -
                          (char *)push_buffer->main.base);
@@ -639,12 +640,35 @@ void __nvPushMakeRoom(NvPushChannelPtr push_buffer, NvU32 count)
     }
     nvAssert(putOffset == push_buffer->main.putOffset);
 
-    while (count >= push_buffer->main.freeDwords) {
+    for (baseTime = currentTime =
+             nvPushImportGetMilliSeconds(push_buffer->pDevice);
+         count >= push_buffer->main.freeDwords;
+         currentTime = nvPushImportGetMilliSeconds(push_buffer->pDevice)) {
+
         if (nvPushCheckChannelError(push_buffer)) {
             nvAssert(!"A channel error occurred in __nvPushMakeRoom()");
             // Unlike with non-gpfifo channels, RC recovery can't reset GET to
             // 0 so we need to continue as if we just started waiting for space.
             return __nvPushMakeRoom(push_buffer, count);
+        }
+
+        if (currentTime > (baseTime + NV_PUSH_NOTIFIER_SHORT_TIMEOUT) &&
+            !push_buffer->noTimeout) {
+            // GET has stopped advancing and no channel error was raised, so no
+            // room will ever free up. Don't spin forever: this function is
+            // void and its callers write unconditionally once it returns, so
+            // give them in-bounds space by wrapping the write pointer back to
+            // the start of the pushbuffer and declaring it free. Each method
+            // write is asserted smaller than sizeInBytes/8, so a full-buffer
+            // grant is always enough. The methods land only in this channel's
+            // own pushbuffer, which the stalled GPU never reads; the ensuing
+            // kickoff fails and the caller (e.g. DIFR prefetch) gives up.
+            nvPushImportLogError(push_buffer->pDevice,
+                "Timed out waiting for room in the pushbuffer.");
+            push_buffer->main.putOffset = 0;
+            push_buffer->main.buffer = push_buffer->main.base;
+            push_buffer->main.freeDwords = push_buffer->main.sizeInBytes >> 2;
+            return;
         }
 
         getOffset = nvPushReadGetOffset(push_buffer, TRUE);

--- a/src/common/unix/nvidia-push/src/nvidia-push.c
+++ b/src/common/unix/nvidia-push/src/nvidia-push.c
@@ -347,6 +347,7 @@ static NvBool nvWriteGpEntry(
 
     NvU32 nextGpPut;
     NvU32 *gpPointer;
+    NvU64 baseTime, currentTime;
     const NvU32 entriesNeeded = NV_PUSH_NUM_GPFIFO_ENTRIES_PER_KICKOFF;
     NvPushDevicePtr pDevice = push_buffer->pDevice;
 
@@ -359,9 +360,19 @@ static NvBool nvWriteGpEntry(
     nvAssert((nextGpPut % 2) == 0);
 
     // Wait for a free entry in the buffer
-    while (nextGpPut == ReadGpGetOffset(push_buffer)) {
+    for (baseTime = currentTime = nvPushImportGetMilliSeconds(pDevice);
+         nextGpPut == ReadGpGetOffset(push_buffer);
+         currentTime = nvPushImportGetMilliSeconds(pDevice)) {
+
         if (nvPushCheckChannelError(push_buffer)) {
             nvAssert(!"A channel error occurred in nvWriteGpEntry()");
+            return FALSE;
+        }
+
+        if (currentTime > (baseTime + NV_PUSH_NOTIFIER_SHORT_TIMEOUT) &&
+            !push_buffer->noTimeout) {
+            nvPushImportLogError(pDevice,
+                "Timed out waiting for a free GPFIFO entry.");
             return FALSE;
         }
     }


### PR DESCRIPTION
## Bound the GPFIFO and pushbuffer waits in nvidia-push

### Problem

nvWriteGpEntry() waits for a free GPFIFO entry with no timeout. __nvPushMakeRoom() waits for pushbuffer space with no timeout. Both loops exit only when the GPU makes progress or a channel error is flagged. If a channel stalls without a flagged error, the loop spins forever in kernel context. When the spinning code holds the nvkms lock, every later modeset blocks in D state and the desktop is unusable until reboot.

I hit this reproducibly with DIFR prefetch after resume from suspend. Same trace as #1167 and #1177.

Environment: RTX 5090, driver 595.71.05 open modules, NVreg_PreserveVideoMemoryAllocations enabled, kernel 7.0.3, KDE Plasma on Wayland, S3 suspend.

The nvidia-modeset kthread spins on one core:

```
RIP: 0010:nvWriteGpEntry+0x90/0x370 [nvidia_modeset]
Call Trace:
 nvPushKickoff+0x24/0x40 [nvidia_modeset]
 PrefetchHelperSurfaceEvo+0x5aa/0x610 [nvidia_modeset]
 nvDIFRPrefetchSurfaces+0xed/0x240 [nvidia_modeset]
 DifrPrefetchEventDeferredWork+0x16/0x30 [nvidia_modeset]
```

and the compositor blocks on the nvkms lock held by that thread:

```
task:kwin_wayland state:D
 down+0x45/0x50
 nvkms_ioctl_from_kapi_try_pmlock+0x36/0x80 [nvidia_modeset]
 ApplyModeSetConfig+0xc7a/0xe00 [nvidia_modeset]
 nv_drm_atomic_check+0x220/0x270 [nvidia_drm]
```

### Fix

Commit 1 bounds nvWriteGpEntry() the same way IdleChannel() already does: poll nvPushImportGetMilliSeconds(), honor the channel noTimeout flag, log an error and return FALSE after NV_PUSH_NOTIFIER_SHORT_TIMEOUT. Kickoff() already handles the FALSE return.

Commit 2 bounds __nvPushMakeRoom() with the same timeout. This function returns void and callers write methods unconditionally after it returns, so on timeout it wraps the write pointer back to the buffer base and marks the whole buffer free. Each method write is asserted smaller than the buffer, so the writes stay in bounds, and they land only in the channel's own pushbuffer. The following kickoff then fails and the caller gives up. Commit 2 is needed because with only commit 1 applied the same stall spins in __nvPushMakeRoom() instead, one call earlier on the same DIFR path. Observed on my machine.

DIFR prefetch already has a failure path for a kickoff that never completes: the semaphore wait in PrefetchSingleSurface() times out and reports NV2080_CTRL_LPWR_DIFR_PREFETCH_FAIL_CE_HW_ERROR. That path was unreachable only because the waits above it could spin first.

Channels created with noTimeout = TRUE keep the old behavior.

### Results

Both commits, rebased onto 595.71.05, have been running on my machine since June 25. The stall occurred six times since then, mostly within seconds of resume. Each time the desktop kept working and the driver logged:

```
nvidia-modeset: ERROR: GPU:0: Timed out waiting for a free GPFIFO entry.
nvidia-modeset: ERROR: GPU:0: Timed out waiting for room in the pushbuffer.
```