### PR TITLE
dp: assume sink capabilities on force-enabled connectors without DPCD

### DIFF
--- a/src/common/displayport/src/dp_configcaps.cpp
+++ b/src/common/displayport/src/dp_configcaps.cpp
@@ -185,6 +185,12 @@ void DPCDHALImpl::parseAndReadCaps()
         // Set an invalid state here and make sure we REMEMBER we couldn't get the caps
         caps.revisionMajor = 0;
         dpcdOffline = true;
+
+        //
+        // Forced/sink-less connector (EDID override, no AUX): fall back to
+        // fake caps so discovery can proceed and create a device.
+        //
+        populateFakeDpcd();
         return;
     }
 
@@ -634,6 +640,14 @@ bool DPCDHALImpl::getSDPExtnForColorimetry()
 {
     bool bSDPExtnForColorimetry = false;
     NvU8 byte = 0;
+    if (dpcdOffline)
+    {
+        //
+        // Forced/sink-less connector: claim VSC SDP colorimetry support so
+        // HDR signaling can be enabled. No real sink interprets the SDP.
+        //
+        return true;
+    }
     if (caps.extendedRxCapsPresent)
     {
         if (AuxRetry::ack == bus.read(NV_DPCD14_EXTENDED_DPRX_FEATURE_ENUM_LIST, &byte,  sizeof byte))
@@ -996,7 +1010,7 @@ void DPCDHALImpl::populateFakeDpcd()
     // this should be extended in for more dpcd offsets in future.
     //
     caps.revisionMajor = 0x1;
-    caps.revisionMinor = 0x1;
+    caps.revisionMinor = 0x4;
     caps.supportsESI = false;
     caps.maxLinkRate = dp2LinkRate_8_10Gbps;
     caps.maxLaneCount = 4;

--- a/src/common/displayport/src/dp_deviceimpl.cpp
+++ b/src/common/displayport/src/dp_deviceimpl.cpp
@@ -1732,6 +1732,15 @@ NvBool DeviceImpl::getDSCSupport()
         }
     }
 
+    else if (hal->isDpcdOffline())
+    {
+        //
+        // Forced/sink-less connector (EDID override, no AUX): assume the
+        // virtual sink can decompress DSC so that high-bandwidth modes pass
+        // validation. The stream is never decoded by a real device.
+        //
+        dscCaps.bDSCDecompressionSupported = true;
+    }
     else
     {
         DP_PRINTF(DP_ERROR, "DP-DEV> DSC Support AUX READ failed for %s!", address.toString(sb));
@@ -2308,6 +2317,11 @@ bool DeviceImpl::getFECSupport()
         bFECSupported = this->bandwidth.enum_path.bPathFECCapable;
     }
 
+    else if (hal->isDpcdOffline())
+    {
+        // Forced/sink-less connector: claim FEC so the DSC path is usable.
+        bFECSupported = true;
+    }
     else if (AuxBus::success == this->getDpcdData(NV_DPCD14_FEC_CAPABILITY,
         &byte, sizeof(byte), &size, &nakReason))
     {
@@ -2560,6 +2574,30 @@ bool DeviceImpl::readAndParseDSCCaps()
     if(AuxBus::success != this->getDpcdData(NV_DPCD14_DSC_SUPPORT,
         &rawDscCaps[0], sizeof(rawDscCaps), &sizeCompleted, &nakReason))
     {
+        if (hal->isDpcdOffline())
+        {
+            //
+            // Forced/sink-less connector: synthesize DSC decoder caps
+            // modeled on a typical DSC 1.2 4K high-refresh monitor.
+            //
+            rawDscCaps[0x0] = 0x01; // decompression supported
+            rawDscCaps[0x1] = 0x21; // DSC algorithm revision 1.2
+            rawDscCaps[0x2] = 0x00; // RC buffer block size
+            rawDscCaps[0x3] = 0x0F; // RC buffer size
+            rawDscCaps[0x4] = 0xFF; // slice caps 1: up to 12 slices
+            rawDscCaps[0x5] = 0x03; // line buffer bit depth: 12
+            rawDscCaps[0x6] = 0x01; // block prediction supported
+            rawDscCaps[0x7] = 0xFF; // max bits per pixel LSB
+            rawDscCaps[0x8] = 0x03; // max bits per pixel MSB (1023/16 bpp)
+            rawDscCaps[0x9] = 0x1F; // color formats: RGB + all YCbCr
+            rawDscCaps[0xA] = 0x0E; // color depth: 8/10/12 bpc
+            rawDscCaps[0xB] = 0xEE; // peak throughput 1000 MP/s both modes
+            rawDscCaps[0xC] = 0x10; // max slice width 5120 px
+            rawDscCaps[0xD] = 0x00; // slice caps 2
+            rawDscCaps[0xE] = 0x00; // branch throughput
+            rawDscCaps[0xF] = 0x00; // bpp increment: 1/16
+            return parseDscCaps(&rawDscCaps[0], sizeof(rawDscCaps));
+        }
         DP_PRINTF(DP_ERROR, "DP-DEV> Error querying DSC Caps on %s!", this->address.toString(sb));
         return false;
     }

--- a/src/nvidia-modeset/include/dp/nvdp-connector.h
+++ b/src/nvidia-modeset/include/dp/nvdp-connector.h
@@ -37,6 +37,8 @@ void nvDPNotifyLongPulse(NVConnectorEvoPtr pConnectorEvo,
 
 void nvDPNotifyShortPulse(NVDPLibConnectorPtr pNVDpLibConnector);
 
+NvBool nvDPConnectorIsPlugged(const NVConnectorEvoRec *pConnectorEvo);
+
 void nvDPDestroyConnector(NVDPLibConnectorPtr pNVDpLibConnector);
 
 NVDPLibModesetStatePtr nvDPLibCreateModesetState(

--- a/src/nvidia-modeset/src/dp/nvdp-connector.cpp
+++ b/src/nvidia-modeset/src/dp/nvdp-connector.cpp
@@ -121,6 +121,12 @@ void nvDPNotifyLongPulse(NVConnectorEvoPtr pConnectorEvo,
 
 }
 
+NvBool nvDPConnectorIsPlugged(const NVConnectorEvoRec *pConnectorEvo)
+{
+    return (pConnectorEvo->pDpLibConnector != NULL) &&
+           pConnectorEvo->pDpLibConnector->plugged;
+}
+
 void nvDPNotifyShortPulse(NVDPLibConnectorPtr pNVDpLibConnector)
 {
     DisplayPort::Connector *c = pNVDpLibConnector->connector;

--- a/src/nvidia-modeset/src/nvkms-dpy.c
+++ b/src/nvidia-modeset/src/nvkms-dpy.c
@@ -22,6 +22,7 @@
  */
 
 #include "dp/nvdp-device.h"
+#include "dp/nvdp-connector.h"
 #include "dp/nvdp-connector-event-sink.h"
 
 #include "nvkms-api-types.h"
@@ -3127,6 +3128,15 @@ NvBool nvDpyGetDynamicData(
         connectedList = nvDPLibDpyIsConnected(pDpyEvo) ?
             oneDpyIdList : nvEmptyDpyIdList();
     } else if (pRequest->forceConnected) {
+        if (nvConnectorUsesDPLib(pConnectorEvo) &&
+            !nvDPConnectorIsPlugged(pConnectorEvo)) {
+            /*
+             * Forced sink-less DP connector (EDID override): simulate a
+             * plug so the DP library performs discovery and creates a
+             * device, enabling DSC/HDR capability paths to be consulted.
+             */
+            nvDPNotifyLongPulse(pConnectorEvo, TRUE);
+        }
         connectedList = oneDpyIdList;
     } else if (pRequest->forceDisconnected) {
         connectedList = nvEmptyDpyIdList();


### PR DESCRIPTION
Hey I've been trying to get virtual displays working for sunshine game streaming. I really want 4k 120 to work for my MacBook Pro to stream my display. To do this and still have my tv connected I this to work on display port.
Obviously this is mostly made with the help of Claude but is tested and works. Please let's get this merged in so I can move to cachy os haha

Hers the Claude description and shout out to inspired pr and issue — #1186 (thanks @Rohithmatham12, this PR follows your approach on the DP side) and #1184:

---

## Problem

A DisplayPort connector that is force-enabled with an EDID override (`video=DP-n:e` + `drm.edid_firmware=...`) and has no physical sink attached is capped at modes that fit the bare assumed link bandwidth — in practice 4K60 — and HDR cannot be enabled on it at all. This makes DP unusable for headless / virtual-display setups (Sunshine/Moonlight game streaming hosts and similar), where the framebuffer is consumed by a screen-capture encoder rather than a physical monitor. This is the DP side of the limitation described in #1184; #1186 addresses the HDMI FRL side.

## Root cause

With no physical sink there is no HPD, so `nvDpyGetDynamicData()` short-circuits the force-connected case without ever notifying the DP library — no discovery runs and no device is created. Even if a long pulse is delivered, `parseAndReadCaps()` fails its AUX read and leaves `revisionMajor = 0`, which makes `notifyLongPulseInternal()` bail out before discovery (`if (!hal->isAtLeastVersion(1, 0)) goto completed`). The result is that mode validation has no sink DSC/FEC caps (so anything above the bare link rate is pruned) and `nvDpyIsHDRCapable()` fails its DPCD revision check (so HDR enable is rejected).

## Change

Four small steps, all gated on the existing `dpcdOffline` state so connectors with a responsive sink take exactly the same paths as before:

1. **`nvDpyGetDynamicData()`** — when a dpy is force-connected on a DP connector the DP library considers unplugged, simulate a long pulse so discovery runs and a device is created.
2. **`DPCDHALImpl::parseAndReadCaps()`** — on a failed caps read, fall back to `populateFakeDpcd()` (previously only done on the unplug path) so discovery can proceed. The faked DPCD revision is raised from 1.1 to 1.4 since HDR requires DPRX 1.3+.
3. **`DeviceImpl::getDSCSupport()` / `readAndParseDSCCaps()` / `getFECSupport()`** — when the AUX read fails and DPCD is offline, synthesize DSC decoder caps modeled on a typical DSC 1.2 4K high-refresh monitor, and claim FEC, so high-bandwidth modes validate through the DSC path.
4. **`DPCDHALImpl::getSDPExtnForColorimetry()`** — claim VSC SDP colorimetry support when DPCD is offline so HDR signaling can be enabled.

## Testing

RTX 3060 Ti (GA104), driver 610.43.02, kernel 7.0.11, KDE Plasma 6.6 Wayland, connector force-enabled via `drm.edid_firmware=DP-2:edid/<file> video=DP-2:e` with an EDID declaring 3840x2160@120:

- Before: connector offers 3840x2160 up to 60 Hz only; HDR enable is rejected by the driver.
- After: discovery runs (`DP> HPD v1.4`, `DPCONN> New device | Native DSC Capability - Capable`), 3840x2160@120 validates and **sets** (DSC Mode = SINGLE), and HDR + wide color gamut enable end to end. Verified streaming the result with Sunshine (KMS capture, HEVC Main10).
- A physically connected DP monitor on the same GPU continues to behave normally (its DPCD reads succeed, so none of the new paths are taken).

Expected, benign noise when the mode is set: `DP-DEV> Error querying DSC Enable State!` — the post-modeset confirmation read has no sink to talk to.

## Open questions for review

- `parseAndReadCaps()` now falls back to fake caps for *any* failed caps read, not just user-forced connectors — the DP library has no visibility into the force-connected flag without new plumbing. The AUX read already retries 16 times before failing, and the unplug path has populated fake DPCD this way for a long time, but if you'd prefer this to be opt-in (a regkey like `APPLY_MAX_LINK_RATE_OVERRIDES`, or plumbing the forced flag through `notifyLongPulse`), happy to rework it.
- The fake DPCD revision bump (1.1 → 1.4) also applies to the existing EDID-locked fake-device path. I didn't find anything that depends on it staying 1.1, but flagging it since that path predates this change.
- The synthesized DSC cap values are my best reading of `parseDscCaps()` and the DPCD 1.4 spec; if there's a preferred canonical set for a virtual sink, glad to switch to it.

Tested in combination with #1186 (the two are independent — this touches only the DP path). Happy to rework any of the above based on feedback.
