### PR TITLE
Unset IsHibernate to avoid resume from GC6/S0ix suspend taking incorrect hibernation resume path 

### DIFF
--- a/src/nvidia/arch/nvalloc/unix/src/dynamic-power.c
+++ b/src/nvidia/arch/nvalloc/unix/src/dynamic-power.c
@@ -2288,6 +2288,7 @@ RmPowerManagement(
                 if (nvp->pm_state.InHibernate)
                 {
                     gpuResumeFromHibernate(pGpu);
+                    nvp->pm_state.InHibernate = NV_FALSE;
                 }
                 else
                 {


### PR DESCRIPTION
With S0ix enabled and using the latest version 610.43.02, the following sequence:
* Hibernate
* Resume from hibernate
* Suspend
* Resume from suspend

Results in no video output and no backlight with spinning fans. Kernel logs reveal an assertion failure:

```
NVRM: nvAssertFailedNoLog: Assertion failed: pKernelPmu->pPrintBuf == NULL @ kern_pmu.c:188
```

After many debug prints I have been able to pinpoint this down to `rm_power_management` picking the wrong branch [here](https://github.com/NVIDIA/open-gpu-kernel-modules/blob/main/src/nvidia/arch/nvalloc/unix/src/dynamic-power.c#L2606) during the final resume (`RmPowerManagement` instead of `RmGcxPowerManagement`). It turns out that the root cause is `InHibernate` never getting reset after resuming from hibernation. Because the _RESUME action conditionally switches the path based on `InHibernate`, the correct GC6 path is used during suspend, but once resume is requested the driver attempts to resume from hibernation instead. I've added a single line to reset `InHibernate` back to false after resuming from hibernation and I can now successfully execute any mix of suspend and hibernate on my machine.

This fixes Bug 5156763 based on [my report on the NVIDIA forums](https://forums.developer.nvidia.com/t/resume-from-suspend-fails-on-system-previously-resumed-from-hibernation/346698) from a while back. The proprietary driver used to dump the exact same assertion failure back when I was still using it, so I suspect the same patch should apply cleanly there as well :)
 