### PR TITLE
ce: fix CeUtils scheduling left paused on error paths in kceTopLevelPceLceMappingsUpdate

### DIFF
--- a/src/nvidia/src/kernel/gpu/ce/kernel_ce.c
+++ b/src/nvidia/src/kernel/gpu/ce/kernel_ce.c
@@ -805,9 +805,10 @@ NV_STATUS kceTopLevelPceLceMappingsUpdate_IMPL(OBJGPU *pGpu, KernelCE *pKCe)
     params.exposeCeMask = exposeCeMask;
     params.bUpdateNvlinkPceLce = bUpdateNvlinkPceLce;
 
-    NV_ASSERT_OK_OR_RETURN(
-        rmapiControlCacheFreeForControl(gpuGetInstance(pGpu),
-                                        NV2080_CTRL_CMD_CE_GET_CE_PCE_MASK));
+    status = rmapiControlCacheFreeForControl(gpuGetInstance(pGpu),
+                                             NV2080_CTRL_CMD_CE_GET_CE_PCE_MASK);
+    if (status != NV_OK)
+        goto cleanup;
 
     // For GSP clients, the update needs to be routed through ctrl call
     params.shimInstance = pKCe->shimInstance;
@@ -822,7 +823,7 @@ NV_STATUS kceTopLevelPceLceMappingsUpdate_IMPL(OBJGPU *pGpu, KernelCE *pKCe)
     {
         NV_PRINTF(LEVEL_ERROR,
             "Failed to update PCE-LCE mappings. Return\n");
-        return status;
+        goto cleanup;
     }
 
     //
@@ -833,6 +834,7 @@ NV_STATUS kceTopLevelPceLceMappingsUpdate_IMPL(OBJGPU *pGpu, KernelCE *pKCe)
     //
     status = kceUpdateClassDB_HAL(pGpu, pKCe);
 
+cleanup:
     ceResumeCeUtilsScheduling(pGpu);
 
     return status;


### PR DESCRIPTION
## Problem

`kceTopLevelPceLceMappingsUpdate_IMPL()` calls `cePauseCeUtilsScheduling()`
to block RM-internal Copy Engine submissions while PCE-LCE mappings are
being reconfigured. The matching `ceResumeCeUtilsScheduling()` is only
reached on the success path, leaving two error paths that return without
resuming:

1. `NV_ASSERT_OK_OR_RETURN()` on `rmapiControlCacheFreeForControl()` —
   the macro returns immediately on failure, bypassing the resume call.
2. The explicit `return status` when
   `NV2080_CTRL_CMD_CE_UPDATE_PCE_LCE_MAPPINGS_V2` fails.

When either path fires, `CeUtils` submission stays permanently paused for
the lifetime of the GPU instance. Subsequent RM-internal CE operations
(memory scrubbing, allocation init) will stall or fail silently.

## Fix

Convert both early returns to `goto cleanup` so `ceResumeCeUtilsScheduling()`
is unconditionally called after the pause, regardless of which path is
taken. The `NV_ASSERT_OK_OR_RETURN()` is replaced with an explicit status
check so the error is captured in `status` before jumping to `cleanup`.

```c
cleanup:
    ceResumeCeUtilsScheduling(pGpu);
    return status;
```

This matches the standard cleanup-label pattern used throughout the RM
codebase for balanced resource acquire/release.