### PR TITLE
Add Linux Kernel 7.2 support

### DIFF
--- a/kernel-open/conftest.sh
+++ b/kernel-open/conftest.sh
@@ -3254,6 +3254,33 @@ compile_test() {
             compile_check_conftest "$CODE" "NV_PTEP_GET_PRESENT" "" "functions"
         ;;
 
+        drm_atomic_commit_present)
+            #
+            # Determine if the kernel has renamed struct drm_atomic_state
+            # to struct drm_atomic_commit.
+            #
+            # Linux kernel commit 5164f7e7ff8e ("drm: Rename struct drm_atomic_state
+            # to drm_atomic_commit") renames the
+            # struct and all associated functions.
+            #
+            echo "$CONFTEST_PREAMBLE
+            #include <drm/drm_atomic.h>
+
+            void conftest(void) {
+                struct drm_atomic_commit *state = NULL;
+            }" > conftest$$.c
+
+            $CC $CFLAGS -c conftest$$.c > /dev/null 2>&1
+            rm -f conftest$$.c
+
+            if [ -f conftest$$.o ]; then
+                rm -f conftest$$.o
+                echo "#define NV_DRM_ATOMIC_COMMIT_PRESENT" | append_conftest "types"
+            else
+                echo "#undef NV_DRM_ATOMIC_COMMIT_PRESENT" | append_conftest "types"
+            fi
+        ;;
+
         drm_plane_atomic_check_has_atomic_state_arg)
             #
             # Determine if drm_plane_helper_funcs::atomic_check takes 'state'

--- a/kernel-open/nvidia-drm/nvidia-drm-conftest.h
+++ b/kernel-open/nvidia-drm/nvidia-drm-conftest.h
@@ -217,4 +217,17 @@ vmf_insert_pfn(struct vm_area_struct *vma, unsigned long addr,
 
 #endif /* defined(NV_BSD) */
 
+/*
+ * Kernel commit 5164f7e7ff8e ("drm: Rename struct drm_atomic_state
+ * to drm_atomic_commit") renamed the struct and all associated functions.
+ */
+#if defined(NV_DRM_ATOMIC_COMMIT_PRESENT)
+#define drm_atomic_state            drm_atomic_commit
+#define drm_atomic_state_alloc      drm_atomic_commit_alloc
+#define drm_atomic_state_put        drm_atomic_commit_put
+#define drm_atomic_state_init       drm_atomic_commit_init
+#define drm_atomic_state_default_clear  drm_atomic_commit_default_clear
+#define drm_atomic_state_default_release drm_atomic_commit_default_release
+#endif
+
 #endif /* defined(__NVIDIA_DRM_CONFTEST_H__) */

--- a/kernel-open/nvidia-drm/nvidia-drm-crtc.c
+++ b/kernel-open/nvidia-drm/nvidia-drm-crtc.c
@@ -1607,13 +1607,17 @@ static int __nv_drm_cursor_atomic_check(struct drm_plane *plane,
 #if defined(NV_DRM_PLANE_ATOMIC_CHECK_HAS_ATOMIC_STATE_ARG)
 static int nv_drm_plane_atomic_check(struct drm_plane *plane,
                                      struct drm_atomic_state *state)
+#elif defined(NV_DRM_ATOMIC_COMMIT_PRESENT)
+static int nv_drm_plane_atomic_check(struct drm_plane *plane,
+                                     struct drm_atomic_commit *state)
 #else
 static int nv_drm_plane_atomic_check(struct drm_plane *plane,
                                      struct drm_plane_state *plane_state)
 #endif
 {
     struct nv_drm_plane *nv_plane = to_nv_plane(plane);
-#if defined(NV_DRM_PLANE_ATOMIC_CHECK_HAS_ATOMIC_STATE_ARG)
+#if defined(NV_DRM_PLANE_ATOMIC_CHECK_HAS_ATOMIC_STATE_ARG) || \
+    defined(NV_DRM_ATOMIC_COMMIT_PRESENT)
     struct drm_plane_state *plane_state =
         drm_atomic_get_new_plane_state(state, plane);
 #endif
@@ -2611,12 +2615,16 @@ static int color_mgmt_config_set_luts(struct nv_drm_crtc_state *nv_crtc_state,
 #if defined(NV_DRM_CRTC_ATOMIC_CHECK_HAS_ATOMIC_STATE_ARG)
 static int nv_drm_crtc_atomic_check(struct drm_crtc *crtc,
                                     struct drm_atomic_state *state)
+#elif defined(NV_DRM_ATOMIC_COMMIT_PRESENT)
+static int nv_drm_crtc_atomic_check(struct drm_crtc *crtc,
+                                    struct drm_atomic_commit *state)
 #else
 static int nv_drm_crtc_atomic_check(struct drm_crtc *crtc,
                                     struct drm_crtc_state *crtc_state)
 #endif
 {
-#if defined(NV_DRM_CRTC_ATOMIC_CHECK_HAS_ATOMIC_STATE_ARG)
+#if defined(NV_DRM_CRTC_ATOMIC_CHECK_HAS_ATOMIC_STATE_ARG) || \
+    defined(NV_DRM_ATOMIC_COMMIT_PRESENT)
     struct drm_crtc_state *crtc_state =
         drm_atomic_get_new_crtc_state(state, crtc);
 #endif

--- a/kernel-open/nvidia-drm/nvidia-drm-sources.mk
+++ b/kernel-open/nvidia-drm/nvidia-drm-sources.mk
@@ -86,6 +86,7 @@ NV_CONFTEST_TYPE_COMPILE_TESTS += drm_driver_has_gem_prime_callbacks
 NV_CONFTEST_TYPE_COMPILE_TESTS += drm_crtc_atomic_check_has_atomic_state_arg
 NV_CONFTEST_TYPE_COMPILE_TESTS += drm_gem_object_vmap_has_map_arg
 NV_CONFTEST_TYPE_COMPILE_TESTS += drm_plane_atomic_check_has_atomic_state_arg
+NV_CONFTEST_TYPE_COMPILE_TESTS += drm_atomic_commit_present
 NV_CONFTEST_TYPE_COMPILE_TESTS += drm_device_has_pdev
 NV_CONFTEST_TYPE_COMPILE_TESTS += drm_crtc_state_has_no_vblank
 NV_CONFTEST_TYPE_COMPILE_TESTS += drm_mode_config_has_allow_fb_modifiers

--- a/kernel-open/nvidia-modeset/nvidia-modeset-linux.c
+++ b/kernel-open/nvidia-modeset/nvidia-modeset-linux.c
@@ -664,9 +664,9 @@ int nvkms_strcmp(const char *s1, const char *s2)
     return strcmp(s1, s2);
 }
 
-char* nvkms_strncpy(char *dest, const char *src, size_t n)
+ssize_t nvkms_strscpy(char *dest, const char *src, size_t count)
 {
-    return strncpy(dest, src, n);
+    return strscpy(dest, src, count);
 }
 
 void nvkms_usleep(NvU64 usec)

--- a/kernel-open/nvidia-modeset/nvidia-modeset-os-interface.h
+++ b/kernel-open/nvidia-modeset/nvidia-modeset-os-interface.h
@@ -149,9 +149,9 @@ int    nvkms_memcmp     (const void *s1,
 size_t nvkms_strlen     (const char *s);
 int    nvkms_strcmp     (const char *s1,
                          const char *s2);
-char*  nvkms_strncpy    (char *dest,
+ssize_t nvkms_strscpy   (char *dest,
                          const char *src,
-                         size_t n);
+                         size_t count);
 void   nvkms_usleep     (NvU64 usec);
 NvU64  nvkms_get_usec   (void);
 int    nvkms_copyin     (void *kptr,

--- a/kernel-open/nvidia-uvm/uvm_pmm_gpu.c
+++ b/kernel-open/nvidia-uvm/uvm_pmm_gpu.c
@@ -2804,7 +2804,7 @@ static NV_STATUS init_chunk_split_cache_level(uvm_pmm_gpu_t *pmm, size_t level)
             size_t size;
             size_t align;
             if (level == 0) {
-                strncpy(chunk_split_cache[level].name, "uvm_gpu_chunk_t", sizeof(chunk_split_cache[level].name) - 1);
+                strscpy(chunk_split_cache[level].name, "uvm_gpu_chunk_t", sizeof(chunk_split_cache[level].name));
                 size = sizeof(uvm_gpu_chunk_t);
                 align = __alignof__(uvm_gpu_chunk_t);
             } else {

--- a/kernel-open/nvidia/export_nvswitch.h
+++ b/kernel-open/nvidia/export_nvswitch.h
@@ -807,12 +807,12 @@ nvswitch_os_strlen
     const char *str
 );
 
-char*
-nvswitch_os_strncpy
+ssize_t
+nvswitch_os_strscpy
 (
     char *pDest,
     const char *pSrc,
-    NvLength length
+    NvLength count
 );
 
 int

--- a/kernel-open/nvidia/linux_nvswitch.c
+++ b/kernel-open/nvidia/linux_nvswitch.c
@@ -2059,7 +2059,7 @@ nvswitch_os_read_registry_dword
         return -NVL_ERR_GENERIC;
     }
 
-    strncpy(regkey_val, regkey_val_start, regkey_val_len);
+    memcpy(regkey_val, regkey_val_start, regkey_val_len);
     regkey_val[regkey_val_len] = '\0';
 
     if (nvswitch_os_strtouint(regkey_val, data) != 0)
@@ -2406,15 +2406,15 @@ nvswitch_os_strlen
     return strlen(str);
 }
 
-char*
-nvswitch_os_strncpy
+ssize_t
+nvswitch_os_strscpy
 (
     char *dest,
     const char *src,
-    NvLength length
+    NvLength count
 )
 {
-    return strncpy(dest, src, length);
+    return strscpy(dest, src, count);
 }
 
 int

--- a/kernel-open/nvidia/os-interface.c
+++ b/kernel-open/nvidia/os-interface.c
@@ -770,8 +770,7 @@ NvU32 NV_API_CALL os_get_current_process(void)
 void NV_API_CALL os_get_current_process_name(char *buf, NvU32 len)
 {
     task_lock(current);
-    strncpy(buf, current->comm, len - 1);
-    buf[len - 1] = '\0';
+    strscpy(buf, current->comm, len);
     task_unlock(current);
 }
 

--- a/src/common/nvswitch/interface/export_nvswitch.h
+++ b/src/common/nvswitch/interface/export_nvswitch.h
@@ -28,6 +28,12 @@
 extern "C" {
 #endif
 
+#if defined(NV_KERNEL_INTERFACE_LAYER) && defined(NV_LINUX)
+#include <linux/types.h>  /* ssize_t */
+#else
+#include <sys/types.h>   /* ssize_t */
+#endif
+
 #include "nv_stdarg.h"
 #include "nvlink_common.h"
 #include "ioctl_common_nvswitch.h"
@@ -803,12 +809,12 @@ nvswitch_os_strlen
     const char *str
 );
 
-char*
-nvswitch_os_strncpy
+ssize_t
+nvswitch_os_strscpy
 (
     char *pDest,
     const char *pSrc,
-    NvLength length
+    NvLength count
 );
 
 int

--- a/src/common/nvswitch/kernel/ls10/smbpbi_ls10.c
+++ b/src/common/nvswitch/kernel/ls10/smbpbi_ls10.c
@@ -178,10 +178,9 @@ nvswitch_smbpbi_send_init_data_ls10
     cmd.hdr.size   = RM_SOE_CMD_SIZE(SMBPBI, INIT_DATA);
     cmd.cmd.smbpbiCmd.cmdType = RM_SOE_SMBPBI_CMD_ID_INIT_DATA;
 
-    nvswitch_os_strncpy((char *)pInitDataCmd->driverVersionString,
+    nvswitch_os_strscpy((char *)pInitDataCmd->driverVersionString,
                         NV_VERSION_STRING,
                         sizeof(pInitDataCmd->driverVersionString));
-    pInitDataCmd->driverVersionString[sizeof(pInitDataCmd->driverVersionString) - 1] = 0;
 
     nvswitch_timeout_create(NVSWITCH_INTERVAL_1SEC_IN_NS, &timeout);
     status = flcnQueueCmdPostBlocking(device, pFlcn,

--- a/src/common/nvswitch/kernel/nvswitch.c
+++ b/src/common/nvswitch/kernel/nvswitch.c
@@ -729,9 +729,7 @@ nvswitch_lib_check_api_version
     }
 
     nvswitch_os_memset(kernel_version, 0x0, length);
-    nvswitch_os_strncpy(kernel_version, NV_VERSION_STRING, VERSION_LENGTH);
-
-    kernel_version[length - 1] = '\0';
+    nvswitch_os_strscpy(kernel_version, NV_VERSION_STRING, VERSION_LENGTH);
 
     if (nvswitch_os_strncmp(user_version, kernel_version, VERSION_LENGTH))
     {

--- a/src/common/nvswitch/kernel/nvswitch.c
+++ b/src/common/nvswitch/kernel/nvswitch.c
@@ -729,7 +729,7 @@ nvswitch_lib_check_api_version
     }
 
     nvswitch_os_memset(kernel_version, 0x0, length);
-    nvswitch_os_strscpy(kernel_version, NV_VERSION_STRING, VERSION_LENGTH);
+    nvswitch_os_strscpy(kernel_version, NV_VERSION_STRING, length);
 
     if (nvswitch_os_strncmp(user_version, kernel_version, VERSION_LENGTH))
     {

--- a/src/nvidia-modeset/kapi/src/nvkms-kapi.c
+++ b/src/nvidia-modeset/kapi/src/nvkms-kapi.c
@@ -475,7 +475,7 @@ static NvBool KmsAllocateDevice(struct NvKmsKapiDevice *device)
 
     /* Allocate NVKMS device */
 
-    nvkms_strncpy(
+    nvkms_strscpy(
         paramsAlloc->request.versionString,
         NV_VERSION_STRING,
         sizeof(paramsAlloc->request.versionString));

--- a/src/nvidia-modeset/os-interface/include/nvidia-modeset-os-interface.h
+++ b/src/nvidia-modeset/os-interface/include/nvidia-modeset-os-interface.h
@@ -31,8 +31,10 @@
 
 #if defined(NV_KERNEL_INTERFACE_LAYER) && defined(NV_LINUX)
 #include <linux/stddef.h>  /* size_t */
+#include <linux/types.h>   /* ssize_t */
 #else
 #include <stddef.h>        /* size_t */
+#include <sys/types.h>     /* ssize_t */
 #endif
 #include "nvtypes.h" /* NvU8 */
 
@@ -149,9 +151,9 @@ int    nvkms_memcmp     (const void *s1,
 size_t nvkms_strlen     (const char *s);
 int    nvkms_strcmp     (const char *s1,
                          const char *s2);
-char*  nvkms_strncpy    (char *dest,
+ssize_t nvkms_strscpy    (char *dest,
                          const char *src,
-                         size_t n);
+                         size_t count);
 void   nvkms_usleep     (NvU64 usec);
 NvU64  nvkms_get_usec   (void);
 int    nvkms_copyin     (void *kptr,

--- a/src/nvidia-modeset/src/dp/nvdp-device.cpp
+++ b/src/nvidia-modeset/src/dp/nvdp-device.cpp
@@ -124,7 +124,7 @@ void nvDPGetDpyGUID(NVDpyEvoPtr pDpyEvo)
 
     str = nvkmsDisplayPort::nvDPGetDeviceGUIDStr(pDpLibDevice->device);
     if (str != NULL) {
-        nvkms_strncpy(pDpyEvo->dp.guid.str, str, sizeof(pDpyEvo->dp.guid.str));
+        nvkms_strscpy(pDpyEvo->dp.guid.str, str, sizeof(pDpyEvo->dp.guid.str));
     } else {
         pDpyEvo->dp.guid.valid = FALSE;
     }

--- a/src/nvidia-modeset/src/nvkms-dpy.c
+++ b/src/nvidia-modeset/src/nvkms-dpy.c
@@ -2311,12 +2311,10 @@ static void PatchAndParseEdid(
 
     for (i = 0; i < NVT_EDID_MAX_LONG_DISPLAY_DESCRIPTOR; i++) {
         if (pParsedEdid->info.ldd[i].tag == NVT_EDID_DISPLAY_DESCRIPTOR_DPSN) {
-            nvkms_strncpy(
+            nvkms_strscpy(
                 pParsedEdid->serialNumberString,
                 (const char *)pParsedEdid->info.ldd[i].u.serial_number.str,
                 sizeof(pParsedEdid->serialNumberString));
-            pParsedEdid->serialNumberString[
-                sizeof(pParsedEdid->serialNumberString) - 1] = '\0';
             break;
         }
     }

--- a/src/nvidia-modeset/src/nvkms-modepool.c
+++ b/src/nvidia-modeset/src/nvkms-modepool.c
@@ -522,9 +522,8 @@ ValidateModeIndexEdid(NVDpyEvoPtr pDpyEvo,
 
         if (description != NULL) {
             nvAssert(nvkms_strlen(description) < sizeof(pReply->description));
-            nvkms_strncpy(pReply->description, description,
+            nvkms_strscpy(pReply->description, description,
                           sizeof(pReply->description));
-            pReply->description[sizeof(pReply->description) - 1] = '\0';
         }
 
         nvBuildModeName(kmsMode.timings.hVisible, kmsMode.timings.vVisible,


### PR DESCRIPTION
This PR replaces `strncpy` with `strscpy` (removed in 7.2 https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=1a3746ccbb0a97bed3c06ccde6b880013b1dddc1) and adds a conftest to handle a 7.2 commit (https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=5164f7e7ff8e) also renaming `drm_atomic_state` to `drm_atomic_commit`.

One of `strncpy` was replaced with memcpy as it is more appropriate than `strscpy`.