### PR TITLE
gsp: don't advertise RTD3 GC6/GC8/GCOFF on external (eGPU) boards

### DIFF
--- a/src/nvidia/src/kernel/gpu/gsp/kernel_gsp.c
+++ b/src/nvidia/src/kernel/gpu/gsp/kernel_gsp.c
@@ -6613,9 +6613,9 @@ _kgspInitGpuProperties(OBJGPU *pGpu)
     GspStaticConfigInfo *pGSCI = GPU_GET_GSP_STATIC_INFO(pGpu);
 
     pGpu->setProperty(pGpu, PDB_PROP_GPU_IS_MOBILE, pGSCI->bIsMobile);
-    pGpu->setProperty(pGpu, PDB_PROP_GPU_RTD3_GC6_SUPPORTED, pGSCI->bIsGc6Rtd3Allowed);
-    pGpu->setProperty(pGpu, PDB_PROP_GPU_RTD3_GC8_SUPPORTED, pGSCI->bIsGc8Rtd3Allowed);
-    pGpu->setProperty(pGpu, PDB_PROP_GPU_RTD3_GCOFF_SUPPORTED, pGSCI->bIsGcOffRtd3Allowed);
+    pGpu->setProperty(pGpu, PDB_PROP_GPU_RTD3_GC6_SUPPORTED, pGSCI->bIsGc6Rtd3Allowed && !pGpu->getProperty(pGpu, PDB_PROP_GPU_IS_EXTERNAL_GPU));
+    pGpu->setProperty(pGpu, PDB_PROP_GPU_RTD3_GC8_SUPPORTED, pGSCI->bIsGc8Rtd3Allowed && !pGpu->getProperty(pGpu, PDB_PROP_GPU_IS_EXTERNAL_GPU));
+    pGpu->setProperty(pGpu, PDB_PROP_GPU_RTD3_GCOFF_SUPPORTED, pGSCI->bIsGcOffRtd3Allowed && !pGpu->getProperty(pGpu, PDB_PROP_GPU_IS_EXTERNAL_GPU));
     pGpu->setProperty(pGpu, PDB_PROP_GPU_IS_UEFI, pGSCI->bIsGpuUefi);
     pGpu->setProperty(pGpu, PDB_PROP_GPU_IS_EFI_INIT, pGSCI->bIsEfiInit);
     pGpu->setProperty(pGpu, PDB_PROP_GPU_LEGACY_GCOFF_SUPPORTED, pGSCI->bIsGcoffLegacyAllowed);


### PR DESCRIPTION
## Summary
`_kgspInitGpuProperties()` advertises RTD3 GC6/GC8/GCOFF support for external (eGPU) boards straight from the GSP silicon capability, with no `IS_EXTERNAL_GPU` check. These are host-platform-coordinated deep power-down states (the host power-gates the GPU's PCIe slot), which is physically impossible for an external GPU in a Thunderbolt/OCuLink enclosure with its own PSU. After the RTD3 idle timeout the GPU attempts the power-down, the GSP firmware faults, and the GPU falls off the PCIe bus.

## Crash (RTX 5090 / GB202 over Thunderbolt, 610.43.02)
```
NVRM: GPU0 _issueRpcAndWait: rpcSendMessage failed status 0x0000000f
NVRM: ... GPU_IN_FULLCHIP_RESET
nvidia-smi: No devices were found
```
Occurs a few minutes after the desktop goes idle. `NVreg_DynamicPowerManagement=0` does not help (it does not override this GSP-set property). The only prior workaround was pinning clocks to max (`nvidia-smi -lgc/-lmc`) to keep the GPU out of idle, at a large constant idle-power cost.

## Fix
Gate `PDB_PROP_GPU_RTD3_{GC6,GC8,GCOFF}_SUPPORTED` on `!PDB_PROP_GPU_IS_EXTERNAL_GPU`. `IS_EXTERNAL_GPU` is already set by `RmCheckForExternalGpu` before `_kgspInitGpuProperties` runs. Orthogonal to dynamic clock scaling: external GPUs keep full dynamic idle clocking (verified P0<->P8, ~38 W idle) while no longer attempting the impossible deep power-down. Zero GSP crashes over a sustained idle test after the change.

Relates to #979.

First-time contributor, happy to sign the CLA or adjust to your process.