### PR TITLE
dkms: ensure shell scripts are executable in builds

### DIFF
--- a/kernel-open/dkms.conf
+++ b/kernel-open/dkms.conf
@@ -2,6 +2,10 @@ PACKAGE_NAME="nvidia"
 PACKAGE_VERSION="__VERSION_STRING"
 AUTOINSTALL="yes"
 
+# Ensure shell scripts are executable before building. DKMS may not preserve
+# file permissions when copying source to the build directory.
+PRE_BUILD="find . -type f -name '*.sh' -exec chmod +x {} +"
+
 # By default, DKMS will add KERNELRELEASE to the make command line; however,
 # this will cause the kernel module build to infer that it was invoked via
 # Kbuild directly instead of DKMS. The dkms(8) manual page recommends quoting


### PR DESCRIPTION
## Problem

Fixes #1258

DKMS build fails during kernel updates because `.sh` scripts in the build directory lack executable permissions (`0644` instead of `0755`).

## Solution

Add `PRE_BUILD` step to `kernel-open/dkms.conf` that finds and `chmod +x` all `.sh` files before building. Uses `find` instead of hardcoded globs to safely handle nested directory structures without glob expansion errors.

## Testing

Syntax verified locally. Full build validation relies on Debian 13 + DKMS environment (reporter's setup).