### PR TITLE
Fix of_gpio compat shim build with CONFIG_OF_GPIO

### DIFF
--- a/kernel-open/common/inc/nv-linux.h
+++ b/kernel-open/common/inc/nv-linux.h
@@ -1724,7 +1724,7 @@ typedef enum
 #else
 #include <linux/gpio/driver.h>
 
-static inline int __to_hwgpio(const struct gpio_device *gdev,
+static inline int __to_hwgpio(struct gpio_device *gdev,
                               const struct of_phandle_args *gpiospec)
 {
 #if defined(CONFIG_OF_GPIO)


### PR DESCRIPTION
`kernel-open` fails to build against Linux 7.1 with clang when the kernel is configured with `CONFIG_OF_GPIO=y`.

610.57.04 added a compat `of_get_named_gpio()` for kernels that no longer ship `linux/of_gpio.h` (removed by `51aaf65bbd21`, "gpio: of: Remove `<linux/of_gpio.h>`", v7.1-rc1). Its helper `__to_hwgpio()` takes a `const struct gpio_device *`, but `gpio_device_get_chip()` has taken a mutable `struct gpio_device *` ever since `9b418780844c` ("gpiolib: reluctantly provide gpio_device_get_chip()"), so the call inside the `CONFIG_OF_GPIO` block discards the qualifier:

```text
common/inc/nv-linux.h:1737:51: error: passing 'const struct gpio_device *' to parameter of type 'struct gpio_device *' discards qualifiers [-Werror,-Wincompatible-pointer-types-discards-qualifiers]
 1737 |     struct gpio_chip *chip = gpio_device_get_chip(gdev);
      |                                                   ^~~~
include/linux/gpio/driver.h:813:60: note: passing argument to parameter 'gdev' here
  813 | struct gpio_chip *gpio_device_get_chip(struct gpio_device *gdev);
```

Three conditions have to line up, which is presumably why it slipped through:

* the shim is only compiled when `linux/of_gpio.h` is absent, i.e. on kernels >= 7.1;
* its body is only compiled with `CONFIG_OF_GPIO=y`, which the usual x86 configurations leave off (it is `def_bool y` under `CONFIG_OF`, and distributions that enable device tree support on x86 for overlays get it implicitly);
* the diagnostic is only fatal under clang. `scripts/Makefile.warn` adds `-Werror=incompatible-pointer-types` unconditionally, and clang has `-Wincompatible-pointer-types-discards-qualifiers` inside that group. GCC reports the same code under the separate `-Wdiscarded-qualifiers`, which the flag does not cover, so GCC builds only warn. `WARNINGS_AS_ERRORS` is not involved.

The `const` is not load-bearing: the only caller is the compat `of_get_named_gpio()` a few lines below, and it holds a mutable `gdev` from `gpio_device_find_by_fwnode()`. Dropping the qualifier is preferable to casting it away at the call site. The only consumer of `of_get_named_gpio()` in the tree is `nvidia/nv-dsi-parse-panel-props.c`, which is Tegra-only, so x86 behaviour is unaffected either way.

Verified by building the open modules of 610.57.04 against Linux 7.1.6 with clang 21 and `CONFIG_OF_GPIO=y`: the build fails as above without this change and completes with it.
