### PR TITLE
nvidia: keep RC timer alive across runtime suspend

### DIFF
--- a/kernel-open/nvidia/nv.c
+++ b/kernel-open/nvidia/nv.c
@@ -3111,7 +3111,8 @@ nvidia_rc_timer_callback(
         return;
     }
 
-    if (rm_run_rc_callback(sp, nv) == NV_OK)
+    status = rm_run_rc_callback(sp, nv);
+    if ((status == NV_OK) || (nv->rc_timer_enabled != 0))
     {
         // set another timeout 1 sec in the future:
         mod_timer(&nvl->rc_timer.kernel_timer, jiffies + HZ);


### PR DESCRIPTION
## TL;DR

Any user with both an integrated GPU and a discrete NVIDIA GPU is affected.

1. The laptop uses the integrated GPU.
2. The unused NVIDIA GPU powers down.
3. NVIDIA's monitoring timer fires while the GPU is powered down and stops permanently.
4. The NVIDIA GPU is later powered up for a game or application.
5. The GPU works, but its monitoring timer remains stopped until reboot.
6. This patch keeps the timer running without waking the powered-down GPU.

## Technical cause

`nvidia_rc_timer_callback()` rearms its one-second timer only when `rm_run_rc_callback()` returns `NV_OK`.

While the GPU is runtime-suspended, `rm_run_rc_callback()` returns `NV_ERR_GENERIC` because `FULL_GPU_SANITY_CHECK()` requires the GPU to be fully powered.

The timer is therefore not rearmed. Nothing starts it again when the GPU resumes, so the one-second callback mechanism remains stopped for the lifetime of the driver instance.

This disables periodic callbacks including the RC watchdog, GPU-presence checking, and GSP log polling. Other fallback mechanisms still exist, so the GPU can continue to work without this timer.

## Fix

Rearm the timer while `rc_timer_enabled` remains set.

`nv_stop_rc_timer()` clears this flag before intentionally stopping the timer, so the change does not restart a deliberately disabled timer.

The timer continues to run on the host, but it does not wake a runtime-suspended NVIDIA GPU.