### PR TITLE
nvidia: defer NVPCF notifications until runtime resume

### DIFF
--- a/src/nvidia/arch/nvalloc/unix/include/nv-priv.h
+++ b/src/nvidia/arch/nvalloc/unix/include/nv-priv.h
@@ -241,6 +241,9 @@ typedef struct nv_dynamic_power_s
     PORT_ATOMIC nv_dynamic_power_state_t state;
     NvS32 refcount;
 
+    /* Coalesced NVPCF notification to replay after runtime resume. */
+    NvBool nvpcf_notify_pending;
+
     /*
      * A word on lock ordering.  These locks must be taken in the order:
      *

--- a/src/nvidia/arch/nvalloc/unix/include/osapi.h
+++ b/src/nvidia/arch/nvalloc/unix/include/osapi.h
@@ -185,6 +185,7 @@ NV_STATUS  RmPowerManagementTegra   (OBJGPU *pGpu, nv_pm_action_t pmAction);
 NV_STATUS  os_ref_dynamic_power     (nv_state_t *, nv_dynamic_power_mode_t);
 void       os_unref_dynamic_power   (nv_state_t *, nv_dynamic_power_mode_t);
 void       RmHandleDisplayChange    (nvidia_stack_t *, nv_state_t *);
+NvBool     RmDeferNvpcfNotifyIfIdle (nv_state_t *);
 void       RmUpdateGc6ConsoleRefCount (nv_state_t *, NvBool);
 
 NvBool     rm_get_uefi_console_status (nv_state_t *);

--- a/src/nvidia/arch/nvalloc/unix/src/dynamic-power.c
+++ b/src/nvidia/arch/nvalloc/unix/src/dynamic-power.c
@@ -172,6 +172,8 @@ static void RmScheduleCallbackToIndicateIdle(OBJGPU *);
 static NvBool RmCheckForGcxSupportOnCurrentState(OBJGPU *);
 static void RmScheduleCallbackToRemoveIdleHoldoff(OBJGPU *);
 static void RmQueueIdleSustainedWorkitem(OBJGPU *);
+static void RmReplayNvpcfNotify(NvU32, void *);
+static void RmQueueNvpcfReplay(OBJGPU *);
 
 /*!
  * @brief Wrapper that checks lock order for the dynamic power mutex.  Locking
@@ -374,6 +376,7 @@ static void RmForceGpuNotIdle(
     nv_priv_t *nvp = NV_GET_NV_PRIV(nv);
     nv_dynamic_power_state_t old_state;
     NvBool ret;
+    NvBool bReplayNvpcf = NV_FALSE;
 
     acquireDynamicPowerMutex(nvp);
 
@@ -383,6 +386,8 @@ static void RmForceGpuNotIdle(
     {
     case NV_DYNAMIC_POWER_STATE_IDLE_INDICATED:
         nv_indicate_not_idle(nv);
+        bReplayNvpcf = nvp->dynamic_power.nvpcf_notify_pending;
+        nvp->dynamic_power.nvpcf_notify_pending = NV_FALSE;
         NV_ASSERT(nvp->dynamic_power.deferred_idle_enabled);
         RmScheduleCallbackForIdlePreConditions(pGpu);
         /* fallthrough */
@@ -407,6 +412,11 @@ static void RmForceGpuNotIdle(
     nv_release_mmap_lock(nv);
 
     releaseDynamicPowerMutex(nvp);
+
+    if (bReplayNvpcf)
+    {
+        RmQueueNvpcfReplay(pGpu);
+    }
 }
 
 /*!
@@ -1109,6 +1119,7 @@ os_ref_dynamic_power(
     nv_priv_t *nvp = NV_GET_NV_PRIV(nv);
     NV_STATUS status = NV_OK;
     NvS32 ref;
+    NvBool bReplayNvpcf = NV_FALSE;
 
     if (nvp == NULL)
     {
@@ -1163,6 +1174,8 @@ os_ref_dynamic_power(
                 nvp->dynamic_power.refcount--;
                 break;
             }
+            bReplayNvpcf = nvp->dynamic_power.nvpcf_notify_pending;
+            nvp->dynamic_power.nvpcf_notify_pending = NV_FALSE;
             if (nvp->dynamic_power.deferred_idle_enabled)
             {
                 RmScheduleCallbackForIdlePreConditions(NV_GET_NV_PRIV_PGPU(nv));
@@ -1184,6 +1197,11 @@ os_ref_dynamic_power(
     }
 
     releaseDynamicPowerMutex(nvp);
+
+    if (bReplayNvpcf)
+    {
+        RmQueueNvpcfReplay(NV_GET_NV_PRIV_PGPU(nv));
+    }
 
     return status;
 }
@@ -1457,6 +1475,65 @@ static void RmRemoveIdleHoldoff(
             RmScheduleCallbackToRemoveIdleHoldoff(pGpu);
         }
     }
+}
+
+static void RmReplayNvpcfNotify(
+    NvU32 gpuInstance,
+    void *pArgs
+)
+{
+    OBJGPU *pGpu = gpumgrGetGpu(gpuInstance);
+
+    gpuNotifySubDeviceEvent(pGpu, NV2080_NOTIFIERS_NVPCF_EVENTS,
+                            NULL, 0, 0, 0);
+}
+
+static void RmQueueNvpcfReplay(
+    OBJGPU *pGpu
+)
+{
+    NV_STATUS status = osQueueWorkItem(pGpu,
+                           RmReplayNvpcfNotify,
+                           NULL,
+                           (OsQueueWorkItemFlags){.bLockGpuGroupSubdevice = NV_TRUE});
+
+    if (status != NV_OK)
+    {
+        nv_state_t *nv = NV_GET_NV_STATE(pGpu);
+        nv_priv_t *nvp = NV_GET_NV_PRIV(nv);
+
+        acquireDynamicPowerMutex(nvp);
+        nvp->dynamic_power.nvpcf_notify_pending = NV_TRUE;
+        releaseDynamicPowerMutex(nvp);
+
+        NV_PRINTF(LEVEL_ERROR,
+                  "Failed to queue deferred NVPCF notification: 0x%x\n",
+                  status);
+    }
+}
+
+/* Check under the mutex so a concurrent resume cannot race the defer. */
+NvBool RmDeferNvpcfNotifyIfIdle(
+    nv_state_t *nv
+)
+{
+    nv_priv_t *nvp = NV_GET_NV_PRIV(nv);
+    NvBool bDefer;
+
+    if (nvp == NULL)
+    {
+        return NV_FALSE;
+    }
+
+    acquireDynamicPowerMutex(nvp);
+    bDefer = nvp->dynamic_power.state == NV_DYNAMIC_POWER_STATE_IDLE_INDICATED;
+    if (bDefer)
+    {
+        nvp->dynamic_power.nvpcf_notify_pending = NV_TRUE;
+    }
+    releaseDynamicPowerMutex(nvp);
+
+    return bDefer;
 }
 
 /*!

--- a/src/nvidia/arch/nvalloc/unix/src/osapi.c
+++ b/src/nvidia/arch/nvalloc/unix/src/osapi.c
@@ -6118,12 +6118,17 @@ void NV_API_CALL rm_acpi_nvpcf_notify(
         if (pGpu != NULL)
         {
             nv_state_t *nv = NV_GET_NV_STATE(pGpu);
-            if ((rmStatus = os_ref_dynamic_power(nv, NV_DYNAMIC_PM_FINE)) ==
-                                                                         NV_OK)
+
+            /*
+             * NVPCF events carry no payload, so coalesce them while suspended
+             * and replay one after resume.
+             */
+            if (!RmDeferNvpcfNotifyIfIdle(nv) &&
+                (os_ref_dynamic_power(nv, NV_DYNAMIC_PM_FINE) == NV_OK))
             {
-               gpuNotifySubDeviceEvent(pGpu, NV2080_NOTIFIERS_NVPCF_EVENTS,
-                                       NULL, 0, 0, 0);
-               os_unref_dynamic_power(nv, NV_DYNAMIC_PM_FINE);
+                gpuNotifySubDeviceEvent(pGpu, NV2080_NOTIFIERS_NVPCF_EVENTS,
+                                        NULL, 0, 0, 0);
+                os_unref_dynamic_power(nv, NV_DYNAMIC_PM_FINE);
             }
         }
         rmapiLockRelease();

--- a/src/nvidia/arch/nvalloc/unix/src/osapi.c
+++ b/src/nvidia/arch/nvalloc/unix/src/osapi.c
@@ -6123,8 +6123,8 @@ void NV_API_CALL rm_acpi_nvpcf_notify(
             {
                gpuNotifySubDeviceEvent(pGpu, NV2080_NOTIFIERS_NVPCF_EVENTS,
                                        NULL, 0, 0, 0);
+               os_unref_dynamic_power(nv, NV_DYNAMIC_PM_FINE);
             }
-            os_unref_dynamic_power(nv, NV_DYNAMIC_PM_FINE);
         }
         rmapiLockRelease();
     }


### PR DESCRIPTION
### TL;DR

On hybrid laptops, the NVIDIA GPU is powered down while idle. However, the firmware can still send NVPCF notifications:

- once per 1% of battery discharge on the tested laptop;
- after a platform-profile change, such as:

```sh
sudo sh -c 'echo balanced > /sys/firmware/acpi/platform_profile'
```

1. The current driver wakes the NVIDIA GPU for approximately 20–22 seconds just to deliver each notification.
2. This patch remembers that the power policy changed without waking the GPU. If more notifications arrive, one reminder is enough because the latest policy will be read later.
3. When the GPU next wakes for actual use, the saved notification is delivered and `nvidia-powerd` reads the latest power limits.

Projected onto typical one-hour scenarios (derived from the measured per-wake cost, not from separate runtime A/B tests):

| Scenario (1 h on battery) | Stock driver | With this patch |
| --- | ---: | ---: |
| Light use, screen off | 93% | 94% |
| Browsing / light work | 90% | 92% |
| Video playback | 78% | 82% |
| Heavier work | 70% | 75% |

Roughly 20% longer projected battery runtime during normal iGPU-only use.

### Problem

On an ASUS GA403UI with an RTX 4070 Laptop GPU, the EC sends `Notify(NPCF, 0xC0)` for every 1% of battery discharge.

`rm_acpi_nvpcf_notify()` takes a dynamic-power reference for every notification, waking the GPU even when it is already runtime-suspended.

Each wake keeps the GPU in D0 for approximately 20–22 seconds while the deferred-idle checks complete.

Measured with driver 610.57.04 and Linux 7.1.6:

- 12 notification-induced wakes during a 90-minute discharge;
- 5.65% dGPU D0 duty while otherwise idle;
- 110.4 ± 19.1 mWh consumed per wake;
- approximately 1.1 W of average overhead in the measured discharge arm.

See also: #860 (same root cause), #905 (NVPCF subset), #1201 (same symptom on two other Zephyrus laptops).

### Why the notification must not be dropped

The notification contains no policy data. It tells subscribers such as `nvidia-powerd` to retrieve the latest policy from the NVPCF `_DSM`.

With notifications discarded while the GPU was suspended, `nvidia-powerd` was not told to retrieve a changed profile. After the GPU resumed, it continued using the old 75/55 W limits instead of the new 90/65 W limits. The limits remained stale until another notification arrived.

This is an alternative to the NVPCF portion of #1181. Both approaches prevent the notification-induced wake, but this change preserves delivery of the notification after the GPU resumes.

### Scope

This change handles NVPCF only.

A platform-profile change also updates the GPU's temperature target, and the firmware announces that with a second, independent notification on the GPU's ACPI device (`ACPI_NOTIFY_GPS_STATUS_CHANGE`, handled by `RmHandleGPSStatusChange()`).

Unlike NVPCF, that notification is consumed by the driver itself rather than by `nvidia-powerd`, and nothing re-reads the value later if it is missed.

This patch leaves it untouched, so on the tested laptop a profile change still wakes the GPU once. Since it only fires on user actions, the cost is negligible.

#1181 suppresses this notification as well.

### How to test (Arch Linux)

```sh
git clone --depth 1 --branch fix-nvpcf-defer-v2 https://github.com/lars76/open-gpu-kernel-modules.git
cd open-gpu-kernel-modules
make modules -j$(nproc)
sudo install -Dm644 kernel-open/*.ko -t "/usr/lib/modules/$(uname -r)/updates/nvidia/"
sudo depmod
sudo mkinitcpio -P
reboot
```

After reboot, verify the patched modules are actually running:

```sh
modinfo -F filename nvidia            # expect .../updates/nvidia/nvidia.ko
cat /sys/module/nvidia/srcversion     # must match:
modinfo kernel-open/nvidia.ko | grep srcversion
```

Then test on battery: unplug at 98% or lower (at 99–100% the battery gauge stalls and the notification does not fire), wait a minute for the unplug wake to settle, and watch

```sh
cat /sys/bus/pci/drivers/nvidia/*/power/runtime_active_time
```

across 2–3% of discharge. Patched: the value stays flat. Stock: it grows by roughly 20,000 ms per 1%. Do not run `nvidia-smi` or `lspci` during the window, as both wake the GPU themselves.

Uninstall:

```sh
sudo rm -r "/usr/lib/modules/$(uname -r)/updates/nvidia"
sudo depmod && sudo mkinitcpio -P
```