### PR TITLE
Honor RMDisableNoncontigAlloc in the PMA vidmem path

### DIFF
--- a/src/nvidia/src/kernel/mem_mgr/video_mem.c
+++ b/src/nvidia/src/kernel/mem_mgr/video_mem.c
@@ -161,6 +161,12 @@ _vidmemPmaAllocate
                                 pAllocData->attr);
     }
 
+    // RMDisableNoncontigAlloc applies to PMA-managed heaps too, not just heapAlloc().
+    if (!pMemoryManager->bAllowNoncontiguousAllocation)
+    {
+        bContig = NV_TRUE;
+    }
+
     NV_PRINTF(LEVEL_INFO, "PMA input\n");
     NV_PRINTF(LEVEL_INFO, "          Owner: 0x%x\n", pAllocData->owner);
     NV_PRINTF(LEVEL_INFO, "        hMemory: 0x%x\n", pAllocRequest->hMemory);
@@ -324,7 +330,7 @@ retry_alloc:
         portMemFree(pAllocRequest->pPmaAllocInfo[subdevInst]);
         pAllocRequest->pPmaAllocInfo[subdevInst] = NULL;
 
-        if (bContig)
+        if (bContig && pMemoryManager->bAllowNoncontiguousAllocation)
         {
             if (FLD_TEST_DRF(OS32, _ATTR, _PHYSICALITY, _ALLOW_NONCONTIGUOUS, pAllocData->attr) ||
                 (FLD_TEST_DRF(OS32, _ATTR, _PHYSICALITY, _DEFAULT, pAllocData->attr) &&


### PR DESCRIPTION
The RMDisableNoncontigAlloc registry key clears
bAllowNoncontiguousAllocation, but the flag is only consulted by vidmemAllocResources() and heapAlloc() on the legacy heap path. _vidmemPmaAllocate() decides contiguity from the client's PHYSICALITY attribute alone and silently retries a failed contiguous allocation as noncontiguous, so the key has no effect on PMA-managed framebuffer heaps, which covers every modern GPU.

Consult the flag in the PMA path as well. When noncontiguous allocation is disabled, allocate contiguously regardless of the requested physicality and skip the noncontiguous retry, so the allocation fails cleanly instead of silently degrading.