### PR TITLE
nvt: only parse per-VIC 3D entries when 3D_present is set

### DIFF
--- a/src/common/modeset/timing/nvt_edidext_861.c
+++ b/src/common/modeset/timing/nvt_edidext_861.c
@@ -3620,7 +3620,7 @@ void parseEdidHDMILLCTiming(NVT_EDID_INFO *pInfo, VSDB_DATA *pVsdb, NvU32 *pMapS
                 }
 
                 // handle any additional per vic modes listed in the EDID
-                while (DataSz > DataCnt)
+                while ((pHDMIVideo->ThreeD_Present) && (DataSz > DataCnt))
                 {
                     // get a pointer to the entry.
                     NVT_3D_MULTI_LIST * pMultiListEntry = (NVT_3D_MULTI_LIST *) &pHdmiLLC->Data[DataCnt];


### PR DESCRIPTION
Fixes HDR being unavailable on HDMI displays whose Vendor Specific Data
Block ends with reserved or padding bytes.

The final loop in parseEdidHDMILLCTiming() is missing the
ThreeD_Present guard that the two preceding 3D parsing blocks have, so
it reinterprets leftover VSDB bytes as per-VIC 3D entries. Any byte
value sets a non-zero stereo mask, so HDMI3DSupported ends up set on
displays that advertise no 3D support at all.

This trips two gates: nvDpyIsHDRCapable() (EINVAL on any BT2020
Colorspace commit, with no kernel log at any debug level) and
SendHDRInfoFrame() (the DRM InfoFrame is never sent, so the display
stays in SDR while the compositor composites in PQ/BT2020).
This accounts for both failure modes people report. If HDR cannot
be enabled at all, it is the first gate. If HDR appears to enable
but the picture is washed out and the display stays in SDR, as 
in #779, it is the second: the compositor composites in 
PQ/BT2020 while the sink is never told to switch.

Reproducer: RTX 5080 (GB203), 610.57.04, kernel 7.1.8, KDE Plasma 6.7.4
Wayland, Acer XV322QK KV over HDMI. Its VSDB is 13 bytes and ends with
one padding byte after two HDMI VICs, with 3D_present = 0 and
HDMI_3D_Len = 0. The parser walk gives DataSz = 5 and DataCnt = 4, so
the loop runs once on the padding byte.

Verified by instrumenting nvDpyIsHDRCapable(): every condition passes
except hdmi3D. Independently confirmed on a stock driver by overriding
the EDID via drm.edid_firmware to widen HDMI_VIC_Len so the trailing
byte is consumed as an (ignored) HDMI VIC instead: HDR then enables and
the monitor leaves SDR.

Note that trailing reserved bytes in a VSDB are expected and are meant
to be ignored by parsers for forward compatibility, so this is likely
to affect a range of displays rather than one vendor's EDID.

A stricter variant would bound the loop by HDMI_3D_Len rather than
gating on ThreeD_Present, which would also cover displays that do
advertise 3D and have padding. I kept the change minimal and
symmetrical with the surrounding code; happy to switch if you prefer.