### PR TITLE
modeset: fix flags overwrite in nvRmMuxPre/nvRmMuxPost

### DIFF
--- a/src/nvidia-modeset/src/nvkms-rm.c
+++ b/src/nvidia-modeset/src/nvkms-rm.c
@@ -5577,9 +5577,9 @@ NvBool nvRmMuxPre(const NVDpyEvoRec *pDpyEvo, NvMuxState state)
     params.flags = DRF_DEF(0073_CTRL_DFP, _DISP_MUX_FLAGS, _SR_ENTER_SKIP, _NO);
 
     if (state == MUX_STATE_DISCRETE) {
-        params.flags = NV0073_CTRL_DFP_DISP_MUX_FLAGS_SWITCH_TYPE_IGPU_TO_DGPU;
+        params.flags |= NV0073_CTRL_DFP_DISP_MUX_FLAGS_SWITCH_TYPE_IGPU_TO_DGPU;
     } else if (state == MUX_STATE_INTEGRATED) {
-        params.flags = NV0073_CTRL_DFP_DISP_MUX_FLAGS_SWITCH_TYPE_DGPU_TO_IGPU;
+        params.flags |= NV0073_CTRL_DFP_DISP_MUX_FLAGS_SWITCH_TYPE_DGPU_TO_IGPU;
     } else {
         return FALSE;
     }
@@ -5672,12 +5672,12 @@ NvBool nvRmMuxPost(const NVDpyEvoRec *pDpyEvo, NvMuxState state)
     }
 
     params.displayId = nvDpyIdToNvU32(pDpyEvo->pConnectorEvo->displayId);
-    params.flags = DRF_DEF(0073_CTRL_DFP, _DISP_MUX_FLAGS, _SR_ENTER_SKIP, _NO);
+    params.flags = DRF_DEF(0073_CTRL_DFP, _DISP_MUX_FLAGS, _SR_EXIT_SKIP, _NO);
 
     if (state == MUX_STATE_DISCRETE) {
-        params.flags = NV0073_CTRL_DFP_DISP_MUX_FLAGS_SWITCH_TYPE_IGPU_TO_DGPU;
+        params.flags |= NV0073_CTRL_DFP_DISP_MUX_FLAGS_SWITCH_TYPE_IGPU_TO_DGPU;
     } else if (state == MUX_STATE_INTEGRATED) {
-        params.flags = NV0073_CTRL_DFP_DISP_MUX_FLAGS_SWITCH_TYPE_DGPU_TO_IGPU;
+        params.flags |= NV0073_CTRL_DFP_DISP_MUX_FLAGS_SWITCH_TYPE_DGPU_TO_IGPU;
     } else {
         return FALSE;
     }


### PR DESCRIPTION
## Summary

Fixes the latent flags bug described in issue #1311.

In `nvRmMuxPre()` and `nvRmMuxPost()` (`src/nvidia-modeset/src/nvkms-rm.c`), `params.flags` is initialized with `DRF_DEF(0073_CTRL_DFP, _DISP_MUX_FLAGS, _SR_ENTER_SKIP, _NO)` and then **overwritten** (not OR-ed) with the switch-type value when a mux state is selected:

```c
params.flags = DRF_DEF(0073_CTRL_DFP, _DISP_MUX_FLAGS, _SR_ENTER_SKIP, _NO);
if (state == MUX_STATE_DISCRETE) {
    params.flags = NV0073_CTRL_DFP_DISP_MUX_FLAGS_SWITCH_TYPE_IGPU_TO_DGPU;
} else if (state == MUX_STATE_INTEGRATED) {
    params.flags = NV0073_CTRL_DFP_DISP_MUX_FLAGS_SWITCH_TYPE_DGPU_TO_IGPU;
}
```

Because the second assignment replaces the whole `flags` word, the initial `_SR_ENTER_SKIP` field is dead code and the driver can never request `NV0073_CTRL_DFP_DISP_MUX_FLAGS_SR_ENTER_SKIP_YES`. Per the RM documentation in `ctrl0073dfp.h`, RM performs the PSR-enter sequence during pre-mux operations unless that bit is set — so on platforms where PSR-enter is unsupported, the entire pre-mux operation fails with `NV_ERR_NOT_SUPPORTED` (issue #1311 reporter hit exactly this).

Additionally, `nvRmMuxPost()` initializes the skip field with the `_SR_ENTER_SKIP` macro, but the POST command defines the field as `_SR_EXIT_SKIP` (bit 1:1 in both cases, so the compiled value is unchanged).

## Changes

- `nvRmMuxPre()`: OR the switch type into `params.flags` instead of overwriting it (`=` → `|=`).
- `nvRmMuxPost()`: same `=` → `|=` fix, and use the correct `_SR_EXIT_SKIP` field in the initial `DRF_DEF`.

## Verification

- Confirmed the flag macros in `ctrl0073dfp.h`: `SWITCH_TYPE` is bit 0:0 (`IGPU_TO_DGPU`=0x0, `DGPU_TO_IGPU`=0x1), `SR_ENTER_SKIP`/`SR_EXIT_SKIP` are bit 1:1 (`_NO`=0x0, `_YES`=0x1).
- `DRF_DEF(...)` expands to `(value << DRF_SHIFT(field))`; with `_NO` it yields 0, so with `|=` the resulting `params.flags` values are byte-identical to before (0x0 for iGPU→dGPU, 0x1 for dGPU→iGPU). No functional change for existing callers — the fix makes the intended flag composition actually reach the RM command and uses the correct field name for the POST command.

No open PR covers this change.