### PR TITLE
nvidia-drm: return -ENOSYS when PRIME sg_table is unavailable

### DIFF
--- a/kernel-open/nvidia-drm/nvidia-drm-gem-nvkms-memory.c
+++ b/kernel-open/nvidia-drm/nvidia-drm-gem-nvkms-memory.c
@@ -381,7 +381,7 @@ static struct sg_table *__nv_drm_gem_nvkms_memory_prime_get_sg_table(
                 nv_dev,
                 "Cannot create sg_table for NvKmsKapiMemory 0x%p",
                 nv_gem->pMemory);
-        return ERR_PTR(-ENOMEM);
+        return ERR_PTR(-ENOSYS);
     }
 
     sg_table = nv_drm_prime_pages_to_sg(nv_dev->dev,


### PR DESCRIPTION
Fixes the misleading error reported in #1302.

## Problem

`__nv_drm_gem_nvkms_memory_prime_get_sg_table()` returns `ERR_PTR(-ENOMEM)` for NvKmsKapiMemory backed by video memory (`pages_count == 0`, no struct pages). The value propagates verbatim through `dma_buf_map_attachment()` to the importing driver: a cross-device PRIME import of such an object reports an out-of-memory condition that never happened. As reported in #1302, kwin_wayland treats this as real memory exhaustion and aborts instead of falling back or reporting an unsupported operation.

## Change

One line: return `ERR_PTR(-ENOSYS)` instead of `ERR_PTR(-ENOMEM)` in that case.

`-ENOSYS` is what DRM core itself uses when a GEM object has no sg_table implementation:

* v5.11 commit d693def4fd1c ("drm: Remove obsolete GEM and PRIME callbacks from struct drm_driver"): `WARN_ON(!obj->funcs->get_sg_table); return ERR_PTR(-ENOSYS);`
* v6.4 commit 207395da5a97 ("drm/prime: reject DMA-BUF attach when get_sg_table is missing"): attach rejected with `-ENOSYS`.

The errno is the only change:

* No caller under kernel-open/nvidia-drm branches on the old value; DRM core forwards `PTR_ERR` unchanged.
* Real allocation failures on this path still return `-ENOMEM` from their own sites.
* `pages_count == 0` occurs only for vidmem objects: sysmem objects whose page list cannot be built fail at object init (`__nv_drm_nvkms_gem_obj_init`).

## Test Plan

Prepared on Windows without Linux kernel toolchain or NVIDIA GPU, so no build and no runtime test were possible; verification was static:

```
git diff --stat
 kernel-open/nvidia-drm/nvidia-drm-gem-nvkms-memory.c | 2 +-

git diff --check        # clean
```

Traced all four constructors of nvkms-memory GEM objects (dumb_create, import_nvkms_memory_ioctl, alloc_nvkms_memory_ioctl, prime_dup) to confirm `pages_count == 0` implies vidmem; grepped all callers of `nv_drm_gem_prime_get_sg_table` for errno-specific branching (none). A hardware test on any multi-GPU system importing a vidmem-backed nvidia-drm buffer from another driver would exercise the changed path.
