### PR TITLE
nvidia-drm: reject out-of-bounds semaphore surface indices

### DIFF
--- a/kernel-open/common/inc/nvkms-kapi.h
+++ b/kernel-open/common/inc/nvkms-kapi.h
@@ -1357,6 +1357,9 @@ struct NvKmsKapiFunctionsTable {
      * \param [out] pMaxSubmittedMap Returns a CPU mapping of the semaphore
      *                               surface's semaphore memory to the client.
      *
+     * \param [out] pSurfaceSize     Returns the size of the imported semaphore
+     *                               surface in bytes. May be NULL.
+     *
      * \return struct NvKmsKapiSemaphoreSurface* on success, NULL on failure.
      */
     struct NvKmsKapiSemaphoreSurface* (*importSemaphoreSurface)
@@ -1365,7 +1368,8 @@ struct NvKmsKapiFunctionsTable {
          NvU64 nvKmsParamsUser,
          NvU64 nvKmsParamsSize,
          void **pSemaphoreMap,
-         void **pMaxSubmittedMap
+         void **pMaxSubmittedMap,
+         NvU64 *pSurfaceSize
     );
 
     /*!

--- a/kernel-open/nvidia-drm/nvidia-drm-fence.c
+++ b/kernel-open/nvidia-drm/nvidia-drm-fence.c
@@ -1231,19 +1231,42 @@ __nv_drm_semsurf_fence_ctx_new(
     struct NvKmsKapiSemaphoreSurface *pSemSurface;
     uint8_t *semMapping;
     uint8_t *maxSubmittedMapping;
+    NvU64 surfaceSize = 0;
     char worker_name[20+16+1]; /* strlen(nvidia-drm/timeline-) + 16 for %llx + NUL */
 
     pSemSurface = nvKms->importSemaphoreSurface(nv_dev->pDevice,
                                                 p->nvkms_params_ptr,
                                                 p->nvkms_params_size,
                                                 (void **)&semMapping,
-                                                (void **)&maxSubmittedMapping);
+                                                (void **)&maxSubmittedMapping,
+                                                &surfaceSize);
     if (!pSemSurface) {
         NV_DRM_DEV_LOG_ERR(
             nv_dev,
             "Failed to import semaphore surface");
 
         goto failed;
+    }
+
+    /*
+     * The index is provided by userspace as a 64-bit value. Reject values
+     * outside the imported surface before shifting the CPU mappings by them,
+     * and before truncating to the 32-bit RM semaphore index below. The
+     * max-submitted value must fit within one stride so that indexing the
+     * semaphore mapping also bounds the max-submitted mapping.
+     */
+    if (nv_dev->semsurf_stride == 0 ||
+        (nv_dev->semsurf_max_submitted_offset + sizeof(NvU64)) >
+            nv_dev->semsurf_stride ||
+        p->index >= (surfaceSize / nv_dev->semsurf_stride) ||
+        p->index > NV_U32_MAX) {
+        NV_DRM_DEV_LOG_ERR(
+            nv_dev,
+            "Invalid semaphore index %" NvU64_fmtu " for semaphore surface of %"
+            NvU64_fmtu " bytes",
+            p->index, surfaceSize);
+
+        goto failed_alloc_fence_context;
     }
 
     /*

--- a/src/nvidia-modeset/kapi/include/nvkms-kapi-internal.h
+++ b/src/nvidia-modeset/kapi/include/nvkms-kapi-internal.h
@@ -237,7 +237,8 @@ nvKmsKapiImportSemaphoreSurface(struct NvKmsKapiDevice *device,
                                 NvU64 nvKmsParamsUser,
                                 NvU64 nvKmsParamsSize,
                                 void **pSemaphoreMap,
-                                void **pMaxSubmittedMap);
+                                void **pMaxSubmittedMap,
+                                NvU64 *pSurfaceSize);
 
 void
 nvKmsKapiFreeSemaphoreSurface(struct NvKmsKapiDevice *device,

--- a/src/nvidia-modeset/kapi/interface/nvkms-kapi.h
+++ b/src/nvidia-modeset/kapi/interface/nvkms-kapi.h
@@ -1357,6 +1357,9 @@ struct NvKmsKapiFunctionsTable {
      * \param [out] pMaxSubmittedMap Returns a CPU mapping of the semaphore
      *                               surface's semaphore memory to the client.
      *
+     * \param [out] pSurfaceSize     Returns the size of the imported semaphore
+     *                               surface in bytes. May be NULL.
+     *
      * \return struct NvKmsKapiSemaphoreSurface* on success, NULL on failure.
      */
     struct NvKmsKapiSemaphoreSurface* (*importSemaphoreSurface)
@@ -1365,7 +1368,8 @@ struct NvKmsKapiFunctionsTable {
          NvU64 nvKmsParamsUser,
          NvU64 nvKmsParamsSize,
          void **pSemaphoreMap,
-         void **pMaxSubmittedMap
+         void **pMaxSubmittedMap,
+         NvU64 *pSurfaceSize
     );
 
     /*!

--- a/src/nvidia-modeset/kapi/src/nvkms-kapi-sync.c
+++ b/src/nvidia-modeset/kapi/src/nvkms-kapi-sync.c
@@ -185,7 +185,8 @@ nvKmsKapiImportSemaphoreSurface
     NvU64 nvKmsParamsUser,
     NvU64 nvKmsParamsSize,
     void **pSemaphoreMap,
-    void **pMaxSubmittedMap
+    void **pMaxSubmittedMap,
+    NvU64 *pSurfaceSize
 )
 {
     struct NvKmsKapiSemaphoreSurface *ss = NULL;
@@ -309,6 +310,10 @@ nvKmsKapiImportSemaphoreSurface
         }
     } else {
         *pMaxSubmittedMap = NULL;
+    }
+
+    if (pSurfaceSize != NULL) {
+        *pSurfaceSize = p.semaphoreSurfaceSize;
     }
 
     return ss;


### PR DESCRIPTION
## Problem

`DRM_IOCTL_NVIDIA_SEMSURF_FENCE_CTX_CREATE` (available with `DRM_RENDER_ALLOW`)
takes a 64-bit semaphore surface index from userspace and uses it unchecked as
an offset into the imported semaphore surface. `nv_drm_semsurf_fence_ctx_create`
passes the index straight to `__nv_drm_get_semsurf_ctx_seqno`, which computes
the slot address from the mapped base pointer plus the shifted index without
any bound against the real surface size. An unprivileged client can therefore
pass any 64-bit index and cause an out-of-bounds read of kernel-mapped memory
at context creation time; the garbage value then becomes the fence's sequence
number.

The wait-side ioctl validates its inputs (#1297 covered a related failure
there), but the context-creation path never bounds the index.

## Change

Two parts:

1. The modeset KAPI `importSemaphoreSurface` call gains an `NvU64 *pSurfaceSize`
   out-parameter so the DRM layer learns the real surface geometry. Both copies
   of the header (`kernel-open/common/inc/nvkms-kapi.h`,
   `src/nvidia-modeset/kapi/interface/nvkms-kapi.h`) are updated identically,
   together with the internal declaration and the `nvkms-kapi-sync.c`
   implementation. This follows existing KAPI signature-change precedent in
   this tree (b5bf85a8 added the pMaxSubmittedMap parameters to the same
   interface).
2. The semaphore surface context constructor rejects bad input before any
   pointer arithmetic:
   - stride == 0
   - index >= surfaceSize / stride
   - index > NV_U32_MAX (RM stores the fence index in a 32-bit field)
   - layouts where maxSubmittedOffset + sizeof(NvU64) > stride, so the
     per-slot tail read stays inside the slot

On constructor failure the imported surface is released exactly once by
jumping to the allocation-failure label instead of the plain failure label,
which previously leaked it while the caller-side cleanup re-freed state.

## Test Plan

Static verification only. This machine is a Windows host with no Linux
toolchain, no kernel headers, and no NVIDIA GPU, so neither `make modules`
nor a runtime reproduction was possible here. Review performed:

- all callers of `importSemaphoreSurface` updated for the new parameter
- every rejection returns before any pointer arithmetic on surface data
- both `nvkms-kapi.h` copies byte-identical
- single-commit diff, no other files touched

Driver tree version: 610.57.04. Hardware/kernel reproduction will follow if
maintainers want one; the code path is reachable from any process with access
to a render node.
