### PR TITLE
fix: adapt dmem_cgroup_register_region for Linux 7.3

### DIFF
--- a/kernel-open/nvidia/os-interface.c
+++ b/kernel-open/nvidia/os-interface.c
@@ -3028,7 +3028,12 @@ void* NV_API_CALL os_cgroup_parent(void *cgroup) { return NULL; }
 #if defined(NV_DMEM_CGROUP_PRESENT)
 void* NV_API_CALL os_dmem_cgroup_register_region(const char *name, NvU64 size, NvU64 precharge, void **prechargePool)
 {
+    #if LINUX_VERSION_CODE >= KERNEL_VERSION(7, 3, 0)
+    struct dmem_cgroup_init init = { .size = size };
+    void *region = dmem_cgroup_register_region(&init, name);
+    #else
     void *region = dmem_cgroup_register_region(size, name);
+    #endif
     if (IS_ERR(region))
     {
         return NULL;


### PR DESCRIPTION
Linux 7.3 updated `dmem_cgroup_register_region()` to accept a pointer to `struct dmem_cgroup_init` instead of a raw `size` argument.

Add a version check to support both `< 7.3` and `>= 7.3` kernels.