### PR TITLE
Honor runtime debug logging for NVKMS KAPI diagnostics

### DIFF
--- a/src/nvidia-modeset/kapi/include/nvkms-kapi-internal.h
+++ b/src/nvidia-modeset/kapi/include/nvkms-kapi-internal.h
@@ -36,12 +36,22 @@
 
 //XXX Decouple functions like nvEvoLog used for logging from NVKMS
 
-#define nvKmsKapiLogDebug(__format...) \
-    nvEvoLogDebug(EVO_LOG_INFO, "[kapi] "__format)
+/* Keep KAPI diagnostics available through the runtime debug switch. */
+#define nvKmsKapiLogDebug(__format...)                         \
+    do {                                                     \
+        if (nvDoDebugLogging()) {                            \
+            nvEvoLog(EVO_LOG_INFO, "[kapi] "__format);         \
+        }                                                    \
+    } while (0)
 
-#define nvKmsKapiLogDeviceDebug(__device, __format, ...)          \
-    nvEvoLogDebug(EVO_LOG_INFO, "[kapi][GPU Id 0x%08x] "__format, \
-                  device->gpuId, ##__VA_ARGS__)
+#define nvKmsKapiLogDeviceDebug(__device, __format, ...)       \
+    do {                                                     \
+        if (nvDoDebugLogging()) {                            \
+            nvEvoLog(EVO_LOG_INFO,                            \
+                     "[kapi][GPU Id 0x%08x] "__format,        \
+                     (__device)->gpuId, ##__VA_ARGS__);       \
+        }                                                    \
+    } while (0)
 
 /*
  * Semaphore values used when using semaphore-based synchronization between


### PR DESCRIPTION
NVKMS KAPI failures currently lose their diagnostic messages in release builds: both KAPI logging macros call `nvEvoLogDebug`, which becomes an empty macro without `DEBUG`. Setting `nvidia-modeset.debug=1` therefore does not expose the existing modeset rejection statuses.

Use `nvEvoLog` behind `nvDoDebugLogging()` for these macros. Logging remains disabled by default in release builds, and debug builds retain their existing logging behavior. The device macro also uses its supplied device argument. Arguments are evaluated only when logging is enabled.

This was found while investigating a four-monitor atomic modeset rejection on an RTX 5090 with 610.43.02: DRM reported `atomic driver check ... failed: -22`, while the runtime NVIDIA debug switch produced no KAPI rejection details. This change enables investigation; it does not claim to fix that display failure.

Validation:

- Built the complete `src/nvidia-modeset` component on current main (610.57.04), release configuration.
- Applied the same patch to 610.43.02 and built its modeset component and `nvidia-modeset.ko` against Ubuntu kernel 7.0.0-30 using the installed Ubuntu kernel interface sources and NVIDIA symbol versions.
- Kernel module build completed with objtool frame-pointer warnings; BTF generation skipped because `vmlinux` was unavailable.
- Hardware loading and runtime log validation remain pending.
