### PR TITLE
uvm: Guard bottom-half queue flush on suspend

### DIFF
--- a/kernel-open/nvidia-uvm/uvm_global.c
+++ b/kernel-open/nvidia-uvm/uvm_global.c
@@ -335,7 +335,8 @@ static NV_STATUS uvm_suspend(void)
 
         uvm_parent_gpu_set_isr_suspended(gpu->parent, true);
 
-        nv_kthread_q_flush(&gpu->parent->isr.bottom_half_q);
+        if (gpu->parent->isr.replayable_faults.handling)
+            nv_kthread_q_flush(&gpu->parent->isr.bottom_half_q);
 
         if (gpu->parent->isr.non_replayable_faults.handling)
             nv_kthread_q_flush(&gpu->parent->isr.kill_channel_q);


### PR DESCRIPTION
## Summary

On Maxwell GPUs, suspending the system while any process has `/dev/nvidia-uvm` open crashes the kernel inside `nvidia_uvm` and hangs the machine. The cause is a queue that `uvm_suspend()` flushes but that was never created on these GPUs. This PR adds the missing check. One line, no behaviour change on GPUs that do create the queue.

Fixes #1212.

## What happens

1. `nvidia-sleep.sh suspend` writes to `/proc/driver/nvidia/suspend`.
2. The driver calls `uvm_suspend()`, which flushes `gpu->parent->isr.bottom_half_q` for every retained GPU.
3. On Maxwell that queue was never initialised, so `_raw_q_schedule()` adds to a NULL list head:

```
BUG: kernel NULL pointer dereference, address: 0000000000000000
RIP: 0010:_raw_q_flush+0x87/0x110 [nvidia_uvm]
 nv_kthread_q_flush+0x18/0x70 [nvidia_uvm]
 uvm_suspend+0x17b/0x1a0 [nvidia_uvm]
 uvm_suspend_entry+0xb6/0xf0 [nvidia_uvm]
 nv_uvm_suspend+0x32/0x50 [nvidia]
 nv_set_system_power_state+0x329/0x510 [nvidia]
 nv_procfs_write_suspend+0x129/0x160 [nvidia]
note: nvidia-sleep.sh exited with irqs disabled
note: nvidia-sleep.sh exited with preempt_count 1
```

4. The crashed task held the queue spinlock with interrupts off, so the real suspend that follows cannot freeze user space (`Freezing user space processes failed ... 1 tasks refusing to freeze`). The display is already off at this point, and the only way out is a hard reset.

## Why

`uvm_parent_gpu_init_isr()` in `uvm_gpu_isr.c` creates `isr.bottom_half_q` only inside `if (parent_gpu->replayable_faults_supported)`, and sets `isr.replayable_faults.handling = true` on the same path. `uvm_maxwell.c` sets `replayable_faults_supported = false`. So on Maxwell the queue struct stays zeroed, and `uvm_suspend()` in `uvm_global.c` flushes it anyway.

The flush right below it, for `kill_channel_q`, is already guarded with `if (gpu->parent->isr.non_replayable_faults.handling)`. The `bottom_half_q` flush just lacks the matching guard.

## Fix

```c
if (gpu->parent->isr.replayable_faults.handling)
    nv_kthread_q_flush(&gpu->parent->isr.bottom_half_q);
```

`replayable_faults.handling` is true exactly when the queue was created. Every GPU supported by the open kernel modules sets it, so this changes nothing for them. It matters for the shared UVM source used by the R580 proprietary driver, the last branch supporting Maxwell, Pascal and Volta. Please carry this into R580.

The unconditional flush is present in 580.173.02, 580.178.04, 590.48.01, 610.57.04 and current `main`. The same crash is reported in #1212 and on the forums:

- https://forums.developer.nvidia.com/t/raw-q-flush-null-deref-in-nvidia-uvm-during-suspend-on-gm108m-580-159-03-kernel-7-0-x/368815
- https://forums.developer.nvidia.com/t/nvidia-uvm-module-bug-on-suspend/273133

## Testing

Testing is in progress and this section will be updated with results. Environment: GeForce GTX 970 (GM204, Maxwell), driver 580.173.02 DKMS (Arch/CachyOS `nvidia-580xx-dkms`), kernel 7.1.3-1-cachyos, `mem_sleep` = deep, `NVreg_PreserveVideoMemoryAllocations=1`, `nvidia-suspend.service` enabled.

Reproduction without the patch is 100%: with any process holding `/dev/nvidia-uvm` open, `systemctl suspend` produces the trace above and the machine has to be hard reset. Suspend succeeds only while no UVM client has retained the GPU, because `uvm_suspend()` then has nothing in `retained_gpus` to flush.
