### PR TITLE
fix: correct conditional rwlock acquisition results

### DIFF
--- a/kernel-open/nvidia/os-interface.c
+++ b/kernel-open/nvidia/os-interface.c
@@ -345,7 +345,7 @@ NV_STATUS NV_API_CALL os_cond_acquire_rwlock_read(void *pRwLock)
 {
     os_rwlock_t *os_rwlock = (os_rwlock_t *)pRwLock;
 
-    if (down_read_trylock(&os_rwlock->sem))
+    if (!down_read_trylock(&os_rwlock->sem))
     {
         return NV_ERR_TIMEOUT_RETRY;
     }
@@ -357,7 +357,7 @@ NV_STATUS NV_API_CALL os_cond_acquire_rwlock_write(void *pRwLock)
 {
     os_rwlock_t *os_rwlock = (os_rwlock_t *)pRwLock;
 
-    if (down_write_trylock(&os_rwlock->sem))
+    if (!down_write_trylock(&os_rwlock->sem))
     {
         return NV_ERR_TIMEOUT_RETRY;
     }


### PR DESCRIPTION
Linux documents [down_read_trylock()](https://github.com/torvalds/linux/blob/v6.17/kernel/locking/rwsem.c#L1571-L1582) and [down_write_trylock()](https://github.com/torvalds/linux/blob/v6.17/kernel/locking/rwsem.c#L1613-L1625) as returning 1 on successful acquisition and 0 on contention.

Negate both checks so the conditional rwlock wrappers return `NV_ERR_TIMEOUT_RETRY` only when acquisition fails, and `NV_OK` when it succeeds.
