### PR TITLE
displayport: restore DSC when active SST displays return

### DIFF
--- a/src/common/displayport/src/dp_groupimpl.cpp
+++ b/src/common/displayport/src/dp_groupimpl.cpp
@@ -153,6 +153,19 @@ void GroupImpl::insert(Device * dev)
             return;
         }
         di->activeGroup = this;
+
+        // A returning SST sink may have lost DSC state while the head stayed
+        // attached. Restore sink decompression and the driver's DSC tracking.
+        if (!parent->linkUseMultistream() &&
+            di->getConnectorType() == connectorDisplayPort &&
+            di->isDSCPossible() &&
+            (dscModeActive == DSC_SINGLE || dscModeActive == DSC_DUAL))
+        {
+            if (!parent->setDeviceDscState(dev, true))
+            {
+                DP_PRINTF(DP_WARNING, "DP-GRP: failed to restore DSC state for active SST head %u.", headIndex);
+            }
+        }
     }
 
     members.insertFront(di);


### PR DESCRIPTION
Reinserting an SST sink into an attached group restored membership without reapplying DSC, so a sink that had lost its enable state could remain blank.

Reapplied DSC through `setDeviceDscState()` for capable DisplayPort sinks in attached SST groups using single or dual DSC, restoring sink decompression and driver tracking.

FEC handling remained unchanged: the captured wakes requested skipping redundant link training, but the existing `train()` path could still configure FEC. Sink FEC state was not separately measured.

[Regression tests](https://github.com/zaclanzon/open-gpu-kernel-modules/tree/982736d2d7bd81063f90127277b53d84e6da1dbb/tests/sst-dsc-restore)
