### PR TITLE
Fix HDMI DSC max-slice code 7 mapping

### DIFF
--- a/src/common/modeset/timing/nvt_edidext_861.c
+++ b/src/common/modeset/timing/nvt_edidext_861.c
@@ -3911,7 +3911,7 @@ void parseEdidHdmiForumVSDB(VSDB_DATA *pVsdb, NVT_HDMI_FORUM_INFO *pHdmiInfo)
             switch(pHdmiForum->DSC_MaxSlices)
             {
             case 8: pHdmiInfo->dsc_MaxSlices = 12; pHdmiInfo->dsc_MaxPclkPerSliceMHz = 900; break;
-            case 7: pHdmiInfo->dsc_MaxSlices = 12; pHdmiInfo->dsc_MaxPclkPerSliceMHz = 600; break;
+            case 7: pHdmiInfo->dsc_MaxSlices = 16; pHdmiInfo->dsc_MaxPclkPerSliceMHz = 400; break;
             case 6: pHdmiInfo->dsc_MaxSlices = 12; pHdmiInfo->dsc_MaxPclkPerSliceMHz = 400; break;
             case 5: pHdmiInfo->dsc_MaxSlices = 8;  pHdmiInfo->dsc_MaxPclkPerSliceMHz = 400; break;
             case 4: pHdmiInfo->dsc_MaxSlices = 8;  pHdmiInfo->dsc_MaxPclkPerSliceMHz = 340; break;


### PR DESCRIPTION
Fixes #1348

Restore HDMI Forum VSDB `DSC_MaxSlices` code 7 to 16 slices at 400 MHz. The 615.71.09 mapping changed it to 12 slices at 600 MHz, but the HDMI DSC throughput path only recognizes the 400 MHz class and otherwise falls back to 340 MHz.

This restores the mapping used in 610.57.04 while leaving the newly added code 8 mapping unchanged.

Validation:
- compiled `src/common/modeset/timing/nvt_edidext_861.c` to `nvt_edidext_861.o` successfully
- `git diff --check`
- confirmed the code 7 mapping matches NVIDIA release 610.57.04

A full Linux kernel-module build was not run on this macOS host because Linux kernel build headers are unavailable. The hardware reproduction and patched-module verification are documented in #1348.
